### PR TITLE
2 bugfixes for SNV handling + workaround for non-inclusive range starts/inclusive range ends

### DIFF
--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -47,7 +47,8 @@ pub fn prob_read_snv(record: &bam::Record, cigar: &[Cigar], start: u32, variant:
         for c in cigar {
             match c {
                 // potential SNV evidence
-                &Cigar::Match(l) | &Cigar::Diff(l) if contains_start(pos, l) => {
+                &Cigar::Match(l) | &Cigar::Diff(l) | &Cigar::Equal(l) if contains_start(pos, l) => {
+                    qpos = start - pos as u32;
                     let read_base = record.seq()[qpos as usize];
                     let base_qual = record.qual()[qpos as usize];
                     let prob_alt = prob_read_base(read_base, base, base_qual);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -514,7 +514,7 @@ impl Sample {
         let (end, varpos) = match variant {
             Variant::Deletion(length)  => (start + length, (start + length / 2) as i32), // TODO do we really need two centerpoints?
             Variant::Insertion(length) => (start + length, start as i32),
-            Variant::SNV(_) => (start, start as i32)
+            Variant::SNV(_) => (start + 1, start as i32)
         };
         let mut pairs = HashMap::new();
         let mut n_overlap = 0;


### PR DESCRIPTION
* non-inclusive range starts and inclusive range ends not in stable Rust, workaround with offsets
* bugfix: include all covering reads for SNVs, i.e. also those that cover the SNV with the first read position
* bugfix: use correct covering position within reads, not always the first of the respective CIGAR operation