### PR TITLE
Constrained sampling of read overlaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 [dependencies]
 bio = "0.10.*"
 log = "0.3.*"
-rust-htslib = "0.9.*"
+rust-htslib = "0.10.*"
 GSL = "0.4.*"
 itertools = "0.5.*"
 itertools-num = "0.1.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 [dependencies]
 bio = "0.10.*"
 log = "0.3.*"
-rust-htslib = "0.10.*"
+rust-htslib = { git = "https://github.com/rust-bio/rust-htslib.git" } #"0.10.*"
 GSL = "0.4.*"
 itertools = "0.5.*"
 itertools-num = "0.1.*"

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -96,8 +96,8 @@ fn pileups<'a, A, B, P>(
 ///
 /// `Result` object with eventual error message.
 pub fn call<A, B, P, M, R, W, X, F>(
-    inbcf: Option<&R>,
-    outbcf: Option<&W>,
+    inbcf: Option<R>,
+    outbcf: Option<W>,
     fasta: &F,
     events: &[PairEvent<A, B>],
     complement_event: Option<&ComplementEvent>,

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -119,7 +119,7 @@ pub fn call<A, B, P, M, R, W, X, F>(
     let fasta = try!(fasta::IndexedReader::from_file(fasta));
     let mut reference_buffer = utils::ReferenceBuffer::new(fasta);
 
-    let inbcf = try!(bcf::Reader::new(inbcf));
+    let inbcf = try!(bcf::Reader::from_path(inbcf));
     let mut header = bcf::Header::with_template(&inbcf.header);
     for event in events {
         header.push_record(
@@ -139,7 +139,7 @@ pub fn call<A, B, P, M, R, W, X, F>(
         Description=\"Maximum a posteriori probability estimate of allele frequency in control sample.\">"
     );
 
-    let mut outbcf = try!(bcf::Writer::new(outbcf, &header, false, false));
+    let mut outbcf = try!(bcf::Writer::from_path(outbcf, &header, false, false));
     let mut outobs = if let Some(f) = outobs {
         let mut writer = try!(csv::Writer::from_file(f)).delimiter(b'\t');
         // write header for observations

--- a/src/estimation/fdr.rs
+++ b/src/estimation/fdr.rs
@@ -20,7 +20,7 @@ pub fn annotate<R, W, E>(inbcf: &R, outbcf: &W, events: &[E]) -> Result<(), Box<
     E: Event
 {
     // read probs
-    let reader = try!(bcf::Reader::new(&inbcf));
+    let reader = try!(bcf::Reader::from_path(&inbcf));
 
     let mut event_peps = Vec::new();
     for _ in 0..events.len() {
@@ -66,7 +66,7 @@ pub fn annotate<R, W, E>(inbcf: &R, outbcf: &W, events: &[E]) -> Result<(), Box<
     // write results
 
     // read bcf again
-    let reader = try!(bcf::Reader::new(&inbcf));
+    let reader = try!(bcf::Reader::from_path(&inbcf));
     let mut outbcf = {
         let mut header = bcf::Header::with_template(&reader.header);
         for event in events {
@@ -74,7 +74,7 @@ pub fn annotate<R, W, E>(inbcf: &R, outbcf: &W, events: &[E]) -> Result<(), Box<
                 event.header_entry("FDR", "PHRED-scaled FDR when considering this and all better").as_bytes()
             );
         }
-        try!(bcf::Writer::new(outbcf, &header, false, false))
+        try!(bcf::Writer::from_path(outbcf, &header, false, false))
     };
 
     let mut i = 0;

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -106,7 +106,7 @@ mod tests {
             prob_alt: LogProb::ln_one(),
             prob_ref: LogProb::ln_zero(),
             prob_mismapped: LogProb::ln_one(),
-            evidence: Evidence::Alignment
+            evidence: Evidence::dummy_alignment()
         };
 
         let lh = model.likelihood_observation(&observation, LogProb::ln_one(), Some(LogProb::ln_zero()));
@@ -141,7 +141,7 @@ mod tests {
                 prob_alt: LogProb::ln_one(),
                 prob_ref: LogProb::ln_zero(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
         for _ in 0..5 {
@@ -150,7 +150,7 @@ mod tests {
                 prob_alt: LogProb::ln_zero(),
                 prob_ref: LogProb::ln_one(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
         let lh = model.likelihood_pileup(&observations, 0.5, Some(0.0));

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -75,6 +75,13 @@ impl Variant {
             _ => false
         }
     }
+
+    pub fn len(&self) -> u32 {
+        match self {
+            &Variant::Deletion(l) | &Variant::Insertion(l) => l,
+            &Variant::SNV(_)       => 1
+        }
+    }
 }
 
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -398,7 +398,7 @@ mod tests {
         let insert_size = InsertSize{ mean: 250.0, sd: 50.0 };
         let prior_model = priors::TumorNormalModel::new(2, 30.0, 1.0, 1.0, 3e9 as u64, Prob(0.001));
         let case_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -410,7 +410,7 @@ mod tests {
             20
         );
         let control_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -447,7 +447,7 @@ mod tests {
                 prob_alt: LogProb::ln_one(),
                 prob_ref: LogProb::ln_zero(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
 
@@ -486,7 +486,7 @@ mod tests {
                 prob_alt: LogProb::ln_one(),
                 prob_ref: LogProb::ln_zero(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
 
@@ -526,7 +526,7 @@ mod tests {
                 prob_alt: LogProb::ln_one(),
                 prob_ref: LogProb::ln_zero(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
         for _ in 0..50 {
@@ -535,7 +535,7 @@ mod tests {
                 prob_alt: LogProb::ln_zero(),
                 prob_ref: LogProb::ln_one(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
 
@@ -573,7 +573,7 @@ mod tests {
                 prob_alt: LogProb::ln_zero(),
                 prob_ref: LogProb::ln_one(),
                 prob_mismapped: LogProb::ln_one(),
-                evidence: Evidence::Alignment
+                evidence: Evidence::dummy_alignment()
             });
         }
 
@@ -601,13 +601,13 @@ mod tests {
     #[test]
     fn test_example1() {
         let variant = Variant::Insertion(2);
-        let case_obs = vec![Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0031672882261573254), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0025150465111820103), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0031672882261573254), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.007974998278512672), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0031723009285603327), prob_alt: LogProb(-111.18254428986242), prob_ref: LogProb(-109.23587762319576), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.003994511005101995), prob_alt: LogProb(-113.14698873430689), prob_ref: LogProb(-111.18254428986242), prob_mismapped: LogProb::ln_one() }];
-        let control_obs = vec![Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0010005003335835337), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0010005003335835337), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.00025122019630215495), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0001585018800054507), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0006311564818346603), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::Alignment, prob_mapping: LogProb(-0.003989017266406586), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }];
+        let case_obs = vec![Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0031672882261573254), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0025150465111820103), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0031672882261573254), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.507675873696745), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.007974998278512672), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_one(), prob_ref: LogProb::ln_zero(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0031723009285603327), prob_alt: LogProb(-111.18254428986242), prob_ref: LogProb(-109.23587762319576), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.003994511005101995), prob_alt: LogProb(-113.14698873430689), prob_ref: LogProb(-111.18254428986242), prob_mismapped: LogProb::ln_one() }];
+        let control_obs = vec![Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0010005003335835337), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.0010005003335835337), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(), prob_mapping: LogProb(-0.00025122019630215495), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.0001585018800054507), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.0006311564818346603), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.00000000010000000000499996), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.0005013128699288086), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }, Observation { evidence: Evidence::dummy_alignment(),prob_mapping: LogProb(-0.003989017266406586), prob_alt: LogProb::ln_zero(), prob_ref: LogProb::ln_one(), prob_mismapped: LogProb::ln_one() }];
 
         let insert_size = InsertSize{ mean: 112.0, sd: 15.0 };
         let prior_model = priors::TumorNormalModel::new(2, 40000.0, 0.5, 0.5, 3e9 as u64, Prob(1.25E-4));
         let case_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -619,7 +619,7 @@ mod tests {
             20,
         );
         let control_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -671,7 +671,7 @@ mod tests {
 
         let insert_size = InsertSize{ mean: 312.0, sd: 15.0 };
         let case_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -683,7 +683,7 @@ mod tests {
             20,
         );
         let control_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -723,7 +723,7 @@ mod tests {
 
         let insert_size = InsertSize{ mean: 312.0, sd: 15.0 };
         let case_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,
@@ -735,7 +735,7 @@ mod tests {
             20,
         );
         let control_sample = Sample::new(
-            bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
+            bam::IndexedReader::from_path(&"tests/test.bam").expect("Error reading BAM."),
             5000,
             true,
             true,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -399,7 +399,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(1.0),
-            Prob(0.0)
+            Prob(0.0),
+            20
         );
         let control_sample = Sample::new(
             bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
@@ -410,7 +411,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(1.0),
-            Prob(0.0)
+            Prob(0.0),
+            20
         );
 
         let model = PairCaller::new(
@@ -607,6 +609,7 @@ mod tests {
             insert_size,
             LatentVariableModel::new(0.75),
             Prob(0.0),
+            20,
         );
         let control_sample = Sample::new(
             bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
@@ -618,6 +621,7 @@ mod tests {
             insert_size,
             LatentVariableModel::new(1.0),
             Prob(0.0),
+            20,
         );
 
         let model = PairCaller::new(
@@ -668,7 +672,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(0.75),
-            Prob(0.00001)
+            Prob(0.00001),
+            20,
         );
         let control_sample = Sample::new(
             bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
@@ -679,7 +684,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(1.0),
-            Prob(0.00001)
+            Prob(0.00001),
+            20,
         );
 
 
@@ -718,7 +724,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(0.75),
-            Prob(0.00001)
+            Prob(0.00001),
+            20,
         );
         let control_sample = Sample::new(
             bam::IndexedReader::new(&"tests/test.bam").expect("Error reading BAM."),
@@ -729,7 +736,8 @@ mod tests {
             false,
             insert_size,
             LatentVariableModel::new(1.0),
-            Prob(0.00001)
+            Prob(0.00001),
+            20,
         );
 
 

--- a/src/model/priors/flat.rs
+++ b/src/model/priors/flat.rs
@@ -220,6 +220,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                 let af_tumor = AlleleFreq(af_tumor);
                 let p = likelihood_tumor(af_tumor, Some(af_normal)) +
                         likelihood_normal(af_normal, None);
+                debug!("L({})={}", *af_tumor, *p);
                 NotNaN::new(*p).expect("posterior probability is NaN")
             }
         ).into_option().expect("prior has empty allele frequency spectrum");

--- a/src/model/priors/flat.rs
+++ b/src/model/priors/flat.rs
@@ -220,7 +220,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                 let af_tumor = AlleleFreq(af_tumor);
                 let p = likelihood_tumor(af_tumor, Some(af_normal)) +
                         likelihood_normal(af_normal, None);
-                debug!("L({})={}", *af_tumor, *p);
+                debug!("L(f_t={}, f_n={})={}", *af_tumor, *af_normal, *p);
                 NotNaN::new(*p).expect("posterior probability is NaN")
             }
         ).into_option().expect("prior has empty allele frequency spectrum");

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -327,7 +327,7 @@ mod tests {
             prob_alt: LogProb::ln_zero(),
             prob_ref: LogProb::ln_one(),
             prob_mismapped: LogProb::ln_one(),
-            evidence: Evidence::Alignment
+            evidence: Evidence::dummy_alignment()
         };
         let obs_alt_abs = Observation {
             prob_mapping: LogProb::ln_one(),
@@ -335,7 +335,7 @@ mod tests {
             prob_alt: LogProb::ln_one(),
             prob_ref: LogProb::ln_zero(),
             prob_mismapped: LogProb::ln_one(),
-            evidence: Evidence::Alignment
+            evidence: Evidence::dummy_alignment()
         };
 
         let mut obs = Vec::new();

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -263,14 +263,14 @@ mod tests {
             prob_alt: LogProb::ln_zero(),
             prob_ref: LogProb::ln_one(),
             prob_mismapped: LogProb::ln_one(),
-            evidence: Evidence::Alignment
+            evidence: Evidence::dummy_alignment()
         };
         let obs_alt_abs = Observation {
             prob_mapping: LogProb::ln_one(),
             prob_alt: LogProb::ln_one(),
             prob_ref: LogProb::ln_zero(),
             prob_mismapped: LogProb::ln_one(),
-            evidence: Evidence::Alignment
+            evidence: Evidence::dummy_alignment()
         };
 
         let mut obs = Vec::new();

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -556,8 +556,8 @@ impl Sample {
         let mut observations = Vec::new();
         let end = match variant {
             Variant::Deletion(length)  => start + length,
-            Variant::Insertion(length) => start,
-            Variant::SNV(_) => (start, start)
+            Variant::Insertion(_) => start,
+            Variant::SNV(_) => start
         };
         let mut pairs = HashMap::new();
         let mut n_overlap = 0;

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -211,7 +211,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
             },
             Variant::Deletion(l) => {
                 // reduce length if deletion is left of p
-                let l = if start >= p { l as u32 } else { l - (p - start) };
+                let l = if start >= p { l as u32 } else { l - (p - start) + 1 };
                 // TODO this will miss one base in some cases.
                 // but it is needed because some callers specify calls as GAA->G and some as AA->*
                 // a better place to fix is when parsing the vcf file.

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -117,8 +117,8 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &CigarString, start: u32, va
         _ => 0
     }).sum();
 
-    // calculate maximal shift to the left without getting outside of the indel start
-    let pos_min = cmp::max(pos.saturating_sub(total_indel_len), start.saturating_sub(m));
+    // calculate maximal shift to the left
+    let pos_min = pos.saturating_sub(total_indel_len);
     // exclusive upper bound
     let pos_max = pos + total_indel_len + 1;
     debug!("cigar: {:?}", cigar);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -123,7 +123,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &CigarString, start: u32, va
     let pos_max = pos + total_indel_len + 1;
     debug!("cigar: {:?}", cigar);
     debug!("calculating indel likelihood for shifts within {} - {}", pos_min, pos_max);
-    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts ({}-{}, pos={}, cigar={})", pos_min, pos_max, pos, cigar);
+    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts ({}-{}, pos={}, cigar={}, m={}, start={})", pos_min, pos_max, pos, cigar, m, start);
 
     let capacity = (pos_max - pos_min) as usize;
     let mut prob_alts = Vec::with_capacity(capacity);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -568,7 +568,7 @@ impl Sample {
                 // iterate over records
                 for record in self.record_buffer.iter() {
                     debug!("--------------");
-                    let skipped = false;
+                    let mut skipped = false;
                     let cigar = record.cigar();
                     let mut pos = record.pos() as u32;
                     let mut end_pos = record.end_pos(&cigar) as u32;

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -118,7 +118,6 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
     let pos_min = cmp::max(pos.saturating_sub(total_indel_len), start.saturating_sub(m));
     // exclusive upper bound
     let pos_max = pos + total_indel_len + 1;
-    debug!("--------------");
     debug!("cigar: {:?}", cigar);
     debug!("calculating indel likelihood for shifts within {} - {}", pos_min, pos_max);
     assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts");
@@ -561,6 +560,8 @@ impl Sample {
 
         // iterate over records
         for record in self.record_buffer.iter() {
+            debug!("--------------");
+
             let cigar = record.cigar();
             let mut pos = record.pos();
             let mut end_pos = record.end_pos(&cigar);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -568,6 +568,7 @@ impl Sample {
                 // iterate over records
                 for record in self.record_buffer.iter() {
                     debug!("--------------");
+                    let skipped = false;
                     let cigar = record.cigar();
                     let mut pos = record.pos() as u32;
                     let mut end_pos = record.end_pos(&cigar) as u32;
@@ -608,8 +609,14 @@ impl Sample {
                             // mate already visited, and this read maps right of varpos
                             debug!("fragment evidence: downstream read");
                             observations.push(self.fragment_observation(&record, *mate_mapq, variant));
+                        } else {
+                            skipped = true;
                         }
                     } else {
+                        skipped = true;
+                    }
+
+                    if skipped {
                         debug!("skipping record: no fragment evindence and overlap={}", overlap);
                     }
                 }

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -606,6 +606,8 @@ impl Sample {
                             // mate already visited, and this read maps right of varpos
                             observations.push(self.fragment_observation(&record, *mate_mapq, variant));
                         }
+                    } else {
+                        debug!("skipping record: no fragment evindence and overlap={}", overlap);
                     }
                 }
             }

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -236,8 +236,9 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
                 };
 
 
-                // reduce length if deletion is left of p
-                let l = if left_of { l as u32 } else { l - (p - start) };
+                // if deletion is left of p, l shall not shift the matches because read has been
+                // aligned after the deletion
+                let l = if left_of { l as u32 } else { 0 };
 
 
                 for i in suffix_start..m {

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -123,7 +123,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &CigarString, start: u32, va
     let pos_max = pos + total_indel_len + 1;
     debug!("cigar: {:?}", cigar);
     debug!("calculating indel likelihood for shifts within {} - {}", pos_min, pos_max);
-    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts ({}-{}, pos={})", pos_min, pos_max, pos);
+    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts ({}-{}, pos={}, cigar={})", pos_min, pos_max, pos, cigar);
 
     let capacity = (pos_max - pos_min) as usize;
     let mut prob_alts = Vec::with_capacity(capacity);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -593,8 +593,8 @@ impl Sample {
                 // iterate over records
                 for record in self.record_buffer.iter() {
                     let cigar = record.cigar();
-                    let mut pos = record.pos() as u32;
-                    let mut end_pos = record.end_pos(&cigar) as u32;
+                    let pos = record.pos() as u32;
+                    let end_pos = record.end_pos(&cigar) as u32;
 
                     let overlap = {
                         // consider soft clips for overlap detection
@@ -632,7 +632,14 @@ impl Sample {
                         if end_pos <= centerpoint {
                             // need to check mate
                             // since the bam file is sorted by position, we can't see the mate first
-                            if record.mpos() as u32 >= centerpoint {
+                            let mpos = record.mpos() as u32;
+                            if mpos >= centerpoint {
+                                debug!(
+                                    "fragment evidence (dist to centerpoint: {}, {}; insert size: {})",
+                                    centerpoint - end_pos,
+                                    mpos - centerpoint,
+                                    record.insert_size()
+                                );
                                 pairs.insert(record.qname().to_owned(), record.mapq());
                             }
                         } else if let Some(mate_mapq) = pairs.get(record.qname()) {

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -144,6 +144,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
     };
 
     for p in pos_min..pos_max {
+        let end = start + variant.len();
         if !(p <= start && p + m >= start) && !(p <= end && p + m >= end) {
             // shift does not overlap the variant
             continue;

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -90,7 +90,7 @@ pub fn prob_read_snv(record: &bam::Record, cigar: &[Cigar], start: u32, variant:
 /// both the alt and the ref case equally.
 pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, variant: Variant, ref_seq: &[u8]) -> (LogProb, LogProb) {
     debug!("--------------");
-    
+
     let mut pos = record.pos() as u32;
     let read_seq = record.seq();
     let m = read_seq.len() as u32;
@@ -144,6 +144,11 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
     };
 
     for p in pos_min..pos_max {
+        if !(p <= start && p + m >= start) && !(p <= end && p + m >= end) {
+            // shift does not overlap the variant
+            continue;
+        }
+
         let mut prob_ref = LogProb::ln_one();
         let mut prob_alt = LogProb::ln_one();
 

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -627,7 +627,7 @@ impl Sample {
         chrom_seq: &[u8]
     ) -> Observation {
         let prob_mapping = self.prob_mapping(record.mapq());
-        debug!("prob_mapping={}", prob_mapping);
+        debug!("prob_mapping={}", *prob_mapping);
 
         let (prob_ref, prob_alt) = match variant {
             Variant::Deletion(_) | Variant::Insertion(_) => {

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -554,9 +554,9 @@ impl Sample {
         chrom_seq: &[u8]
     ) -> Result<Vec<Observation>, Box<Error>> {
         let mut observations = Vec::new();
-        let (end, varpos) = match variant {
-            Variant::Deletion(length)  => (start + length, start + length / 2),
-            Variant::Insertion(length) => (start + length, start),
+        let end = match variant {
+            Variant::Deletion(length)  => start + length,
+            Variant::Insertion(length) => start,
             Variant::SNV(_) => (start, start)
         };
         let mut pairs = HashMap::new();
@@ -618,15 +618,14 @@ impl Sample {
                         }
                     } else if self.use_fragment_evidence &&
                        (record.is_first_in_template() || record.is_last_in_template()) {
-                        // TODO get rid of varpos
-                        if end_pos <= varpos {
+                        if end_pos <= start {
                             // need to check mate
                             // since the bam file is sorted by position, we can't see the mate first
-                            if record.mpos() as u32 >= varpos {
+                            if record.mpos() as u32 >= end {
                                 pairs.insert(record.qname().to_owned(), record.mapq());
                             }
                         } else if let Some(mate_mapq) = pairs.get(record.qname()) {
-                            // mate already visited, and this read maps right of varpos
+                            // mate already visited, and this read maps right of end
                             observations.push(self.fragment_observation(&record, *mate_mapq, variant));
                         }
                     }

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -635,10 +635,11 @@ impl Sample {
                             let mpos = record.mpos() as u32;
                             if mpos >= centerpoint {
                                 debug!(
-                                    "fragment evidence (dist to centerpoint: {}, {}; insert size: {})",
+                                    "fragment evidence (dist to centerpoint: {}, {}; insert size: {}, cigar: {})",
                                     centerpoint - end_pos,
                                     mpos - centerpoint,
-                                    record.insert_size()
+                                    record.insert_size(),
+                                    cigar
                                 );
                                 pairs.insert(record.qname().to_owned(), record.mapq());
                             }

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -644,6 +644,7 @@ impl Sample {
                                 pairs.insert(record.qname().to_owned(), record.mapq());
                             }
                         } else if let Some(mate_mapq) = pairs.get(record.qname()) {
+                            debug!("fragment mate (cigar: {})", cigar);
                             // mate already visited, and this read maps right of end
                             observations.push(self.fragment_observation(&record, *mate_mapq, variant));
                         }

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -123,7 +123,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &CigarString, start: u32, va
     let pos_max = pos + total_indel_len + 1;
     debug!("cigar: {:?}", cigar);
     debug!("calculating indel likelihood for shifts within {} - {}", pos_min, pos_max);
-    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts");
+    assert!(pos >= pos_min && pos <= pos_max, "original mapping position should be within the evaluated shifts ({}-{}, pos={})", pos_min, pos_max, pos);
 
     let capacity = (pos_max - pos_min) as usize;
     let mut prob_alts = Vec::with_capacity(capacity);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -588,6 +588,7 @@ impl Sample {
 
                     if overlap > 0 {
                         if overlap <= self.max_indel_overlap {
+                            debug!("read evidence");
                             observations.push(
                                 self.read_observation(&record, &cigar, start, variant, chrom_seq)
                             );
@@ -600,10 +601,12 @@ impl Sample {
                             // need to check mate
                             // since the bam file is sorted by position, we can't see the mate first
                             if record.mpos() as u32 >= varpos {
+                                debug!("fragment evidence: upstream read");
                                 pairs.insert(record.qname().to_owned(), record.mapq());
                             }
                         } else if let Some(mate_mapq) = pairs.get(record.qname()) {
                             // mate already visited, and this read maps right of varpos
+                            debug!("fragment evidence: downstream read");
                             observations.push(self.fragment_observation(&record, *mate_mapq, variant));
                         }
                     } else {

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -11,7 +11,7 @@ use rgsl::randist::gaussian::{gaussian_pdf, ugaussian_P};
 use rgsl::error::erfc;
 use rust_htslib::bam;
 use rust_htslib::bam::Read;
-use rust_htslib::bam::record::Cigar;
+use rust_htslib::bam::record::{Cigar, CigarString};
 use bio::stats::{LogProb, PHREDProb, Prob};
 use itertools;
 
@@ -89,7 +89,7 @@ pub fn prob_read_snv(record: &bam::Record, cigar: &[Cigar], start: u32, variant:
 /// such that they simply lead to globally reduced likelihoods, which are normalized away by bayes theorem.
 /// Other homo/heterozgous variants on the same haplotype as the investigated are no problem. They will affect
 /// both the alt and the ref case equally.
-pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, variant: Variant, ref_seq: &[u8]) -> (LogProb, LogProb) {
+pub fn prob_read_indel(record: &bam::Record, cigar: &CigarString, start: u32, variant: Variant, ref_seq: &[u8]) -> (LogProb, LogProb) {
     debug!("--------------");
 
     let mut pos = record.pos() as u32;
@@ -472,10 +472,10 @@ impl Evidence {
 }
 
 
-impl<'a, Cigar> From<&'a [Cigar]> for Evidence
-where Cigar: fmt::Debug {
-    fn from(cigar: &[Cigar]) -> Self {
-        Evidence::Alignment(format!("{:?}", cigar))
+impl<'a, CigarString> From<&'a CigarString> for Evidence
+where CigarString: fmt::Display {
+    fn from(cigar: &CigarString) -> Self {
+        Evidence::Alignment(format!("{}", cigar))
     }
 }
 
@@ -658,7 +658,7 @@ impl Sample {
     fn read_observation(
         &self,
         record: &bam::Record,
-        cigar: &[Cigar],
+        cigar: &CigarString,
         start: u32,
         variant: Variant,
         chrom_seq: &[u8]

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -211,7 +211,7 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
             },
             Variant::Deletion(l) => {
                 // reduce length if deletion is left of p
-                let l = if start >= p { l as u32 } else { l - (p - start) + 1 };
+                let l = if start >= p { l as u32 } else { l - (p - start) - 1 };
                 // TODO this will miss one base in some cases.
                 // but it is needed because some callers specify calls as GAA->G and some as AA->*
                 // a better place to fix is when parsing the vcf file.

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -164,9 +164,11 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
         }
 
         if log_enabled!(Debug) {
-            alt_matches.as_mut().unwrap().push('|');
-            ref_matches.as_mut().unwrap().push('|');
-            ref_matches.as_mut().unwrap().push('|');
+            if prefix_end != 0 {
+                alt_matches.as_mut().unwrap().push('|');
+                ref_matches.as_mut().unwrap().push('|');
+                ref_matches.as_mut().unwrap().push('|');
+            }
         }
 
         // ref likelihood
@@ -223,6 +225,10 @@ pub fn prob_read_indel(record: &bam::Record, cigar: &[Cigar], start: u32, varian
                             let x = debug_match(i, p + i - l);
                             alt_matches.as_mut().unwrap().push(x);
                         }
+                    }
+
+                    if log_enabled!(Debug) {
+                        alt_matches.as_mut().unwrap().push('|');
                     }
                 }
 


### PR DESCRIPTION
For indels, we now sample reads that overlap the start or end of the variant by a configurable maximum. This ensures that alt and ref reads are sampled without bias.
Otherwise, the bias is as follows. If the overlap is too large, an alt read is (a) softclipped but with reduced MAPQ, (b) hardclipped such that the alt sequence is lost, (c) not mapped at all. All three cases are unfair compared to the ref reads and lead to biased allele frequency estimates.