### PR TITLE
FDR for vectors of `Event`s / sets of `Event`s

### DIFF
--- a/src/estimation/fdr/bh.rs
+++ b/src/estimation/fdr/bh.rs
@@ -37,12 +37,12 @@ pub fn control_fdr<E: Event, W: io::Write>(
     calls: &mut bcf::Reader,
     null_calls: &mut bcf::Reader,
     writer: &mut W,
-    event: &E,
+    events: &Vec<E>,
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
     let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
     try!(writer.write(["FDR", "max-prob"].into_iter()));
 
-    let null_dist = utils::collect_prob_dist(null_calls, event, vartype)?;
+    let null_dist = utils::collect_prob_dist(null_calls, events, vartype)?;
 
     if null_dist.is_empty() {
         for &alpha in &ALPHAS {
@@ -51,7 +51,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
         return Ok(());
     }
 
-    let prob_dist = utils::collect_prob_dist(calls, event, vartype)?;
+    let prob_dist = utils::collect_prob_dist(calls, events, vartype)?;
     debug!("{} observations in null distribution.", null_dist.len());
     debug!("{} observations in call distribution.", prob_dist.len());
     let pvals = prob_dist.iter().map(|&p| pval(p, &null_dist)).collect_vec();

--- a/src/estimation/fdr/bh.rs
+++ b/src/estimation/fdr/bh.rs
@@ -37,7 +37,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
     calls: &mut bcf::Reader,
     null_calls: &mut bcf::Reader,
     writer: &mut W,
-    events: &Vec<E>,
+    events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
     let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
     try!(writer.write(["FDR", "max-prob"].into_iter()));

--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -29,7 +29,7 @@ use utils;
 pub fn control_fdr<E: Event, W: io::Write>(
     calls: &mut bcf::Reader,
     writer: &mut W,
-    events: &Vec<E>,
+    events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
     let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
     try!(writer.write(["FDR", "max-prob"].into_iter()));

--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -24,17 +24,17 @@ use utils;
 /// * `calls` - BCF reader with prosic calls
 /// * `null_calls` - calls under the null model, e.g. obtained by swapping tumor and normal sample
 /// * `writer` - writer for resulting thresholds
-/// * `event` - the event to control
+/// * `events` - the set of events to control (sum of the probabilities of the individual events at a site)
 /// * `vartype` - the variant type to consider
 pub fn control_fdr<E: Event, W: io::Write>(
     calls: &mut bcf::Reader,
     writer: &mut W,
-    event: &E,
+    events: &Vec<E>,
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
     let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
     try!(writer.write(["FDR", "max-prob"].into_iter()));
 
-    let prob_dist = utils::collect_prob_dist(calls, event, vartype)?;
+    let prob_dist = utils::collect_prob_dist(calls, events, vartype)?;
 
     if prob_dist.is_empty() {
         for &alpha in &ALPHAS {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -182,7 +182,7 @@ impl ReferenceBuffer {
 /// * `vartype` - the variant type to consider
 pub fn collect_prob_dist<E: Event>(
     calls: &bcf::Reader,
-    events: &Vec<E>,
+    events: &[E],
     vartype: &model::VariantType) -> Result<Vec<NotNaN<f64>>, Box<Error>> {
     let mut record = bcf::Record::new();
     let mut prob_dist = Vec::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -197,7 +197,7 @@ pub fn collect_prob_dist<E: Event>(
         }
 
         let variants = try!(utils::collect_variants(&mut record, false, false, None, false));
-        let events_prob_sum = LogProb::ln_zero();
+        let mut events_prob_sum = LogProb::ln_zero();
         for tag in &tags {
             if let Some(event_probs) = try!(record.info(tag.as_bytes()).float()) {
                 //tag present
@@ -206,16 +206,76 @@ pub fn collect_prob_dist<E: Event>(
                         if !variant.is_type(vartype) || event_prob.is_nan() {
                             continue;
                         }
-                        events_prob_sum.ln_add_exp(LogProb::from(PHREDProb( *event_prob as f64)));
+                        events_prob_sum = events_prob_sum.ln_add_exp( LogProb::from( PHREDProb( *event_prob as f64 ) ) );
                     }
                 }
 
             }
         }
-        prob_dist.push(try!(NotNaN::new(*events_prob_sum)));
+        prob_dist.push(try!(NotNaN::new( *events_prob_sum ) ));
     }
     prob_dist.sort();
     Ok(prob_dist)
 }
 
-//TODO: tests for collect_prob_dist()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rust_htslib::bcf;
+    use bio::stats::Prob;
+    use model::VariantType;
+    use ComplementEvent;
+    use SimpleEvent;
+
+    #[test]
+    fn test_collect_prob_dist() {
+        // setup events with names as in prosic2
+        let events = vec![
+            SimpleEvent { name: "germline".to_owned() },
+            SimpleEvent { name: "somatic".to_owned() }
+        ];
+        // setup absent event as the complement of the other events
+        let absent_event = vec![ ComplementEvent { name: "absent".to_owned() } ];
+
+        let test_file = "tests/resources/test_collect_prob_dist/min.calls.vcf";
+
+        //TESTS deletion
+        let del = VariantType::Deletion(None);
+
+        let del_calls_1 = bcf::Reader::from_path( test_file ).unwrap();
+        if let Ok(prob_del) = collect_prob_dist(&del_calls_1, &events, &del) {
+            println!("prob_del[0]: {:?}", prob_del[0].into_inner() );
+            assert_eq!( prob_del.len(), 3 );
+            assert_relative_eq!( prob_del[2].into_inner(), Prob(0.8).ln(), epsilon = 0.000005 );
+        } else {
+            panic!("collect_prob_dist(&calls, &events, &del) returned Error")
+        }
+        let del_calls_2 = bcf::Reader::from_path( test_file ).unwrap();
+        if let Ok(prob_del_abs) = collect_prob_dist(&del_calls_2, &absent_event, &del) {
+            assert_eq!( prob_del_abs.len(), 3 );
+            assert_relative_eq!( prob_del_abs[2].into_inner(), Prob(0.2).ln(), epsilon = 0.000005 );
+        } else {
+            panic!("collect_prob_dist(&calls, &absent_event, &del) returned Error")
+        }
+
+        //TESTS insertion
+        let ins = VariantType::Insertion(None);
+
+        let ins_calls_1 = bcf::Reader::from_path( test_file ).unwrap();
+        if let Ok(prob_ins) = collect_prob_dist(&ins_calls_1, &events, &ins) {
+            assert_eq!( prob_ins.len(), 3 );
+            assert_relative_eq!( prob_ins[2].into_inner(), Prob(0.2).ln(), epsilon = 0.000005 );
+        } else {
+            panic!("collect_prob_dist(&calls, &events, &ins) returned Error")
+        }
+        let ins_calls_2 = bcf::Reader::from_path( test_file ).unwrap();
+        if let Ok(prob_ins_abs) = collect_prob_dist(&ins_calls_2, &absent_event, &ins) {
+            assert_eq!( prob_ins_abs.len(), 3 );
+            assert_relative_eq!( prob_ins_abs[2].into_inner(), Prob(0.8).ln(), epsilon = 0.000005 );
+        } else {
+            panic!("collect_prob_dist(&calls, &absent_event, &ins) returned Error")
+        }
+    }
+
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -196,10 +196,10 @@ pub fn collect_prob_dist<E: Event>(
             }
         }
 
-        let variants = try!(utils::collect_variants(&mut record, false, false, None, false));
+        let variants = (utils::collect_variants(&mut record, false, false, None, false))?;
         let mut events_prob_sum = LogProb::ln_zero();
         for tag in &tags {
-            if let Some(event_probs) = try!(record.info(tag.as_bytes()).float()) {
+            if let Some(event_probs) = (record.info(tag.as_bytes()).float())? {
                 //tag present
                 for (variant, event_prob) in (&variants).into_iter().zip(event_probs.into_iter()) {
                     if let Some(ref variant) = *variant {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -210,7 +210,7 @@ fn control_fdr_ev(test: &str) {
     libprosic::estimation::fdr::ev::control_fdr(
         &mut calls,
         &mut writer,
-        &libprosic::SimpleEvent { name: "SOMATIC".to_owned() },
+        &vec![ libprosic::SimpleEvent { name: "SOMATIC".to_owned() } ],
         &libprosic::model::VariantType::Deletion(Some(1..30))
     ).unwrap();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -210,7 +210,7 @@ fn control_fdr_ev(test: &str) {
     libprosic::estimation::fdr::ev::control_fdr(
         &mut calls,
         &mut writer,
-        &vec![ libprosic::SimpleEvent { name: "SOMATIC".to_owned() } ],
+        &[ libprosic::SimpleEvent { name: "SOMATIC".to_owned() } ],
         &libprosic::model::VariantType::Deletion(Some(1..30))
     ).unwrap();
 }

--- a/tests/resources/test_collect_prob_dist/min.calls.vcf
+++ b/tests/resources/test_collect_prob_dist/min.calls.vcf
@@ -1,0 +1,85 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20161029
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=INV,Description="Inversion">
+##ALT=<ID=TRA,Description="Translocation">
+##ALT=<ID=INS,Description="Insertion">
+##FILTER=<ID=LowQual,Description="PE/SR support below 3 or mapping quality below 20.">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="PE confidence interval around END">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="PE confidence interval around POS">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome for END coordinate in case of a translocation">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the structural variant">
+##INFO=<ID=PE,Number=1,Type=Integer,Description="Paired-end support of the structural variant">
+##INFO=<ID=MAPQ,Number=1,Type=Integer,Description="Median mapping quality of paired-ends">
+##INFO=<ID=SR,Number=1,Type=Integer,Description="Split-read support">
+##INFO=<ID=SRQ,Number=1,Type=Float,Description="Split-read consensus alignment quality">
+##INFO=<ID=CONSENSUS,Number=1,Type=String,Description="Split-read consensus sequence">
+##INFO=<ID=CE,Number=1,Type=Float,Description="Consensus sequence entropy">
+##INFO=<ID=CT,Number=1,Type=String,Description="Paired-end signature induced connection type">
+##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
+##INFO=<ID=PRECISE,Number=0,Type=Flag,Description="Precise structural variation">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=SVMETHOD,Number=1,Type=String,Description="Type of approach used to detect SV">
+##INFO=<ID=INSLEN,Number=1,Type=Integer,Description="Predicted length of the insertion">
+##INFO=<ID=HOMLEN,Number=1,Type=Integer,Description="Predicted microhomology length using a max. edit distance of 2">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Log10-scaled genotype likelihoods for RR,RA,AA genotypes">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Per-sample genotype filter">
+##FORMAT=<ID=RC,Number=1,Type=Integer,Description="Raw high-quality read counts for the SV">
+##FORMAT=<ID=RCL,Number=1,Type=Integer,Description="Raw high-quality read counts for the left control region">
+##FORMAT=<ID=RCR,Number=1,Type=Integer,Description="Raw high-quality read counts for the right control region">
+##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Read-depth based copy-number estimate for autosomal sites">
+##FORMAT=<ID=DR,Number=1,Type=Integer,Description="# high-quality reference pairs">
+##FORMAT=<ID=DV,Number=1,Type=Integer,Description="# high-quality variant pairs">
+##FORMAT=<ID=RR,Number=1,Type=Integer,Description="# high-quality reference junction reads">
+##FORMAT=<ID=RV,Number=1,Type=Integer,Description="# high-quality variant junction reads">
+##reference=../../data/ref/hg18.fasta
+##contig=<ID=chr1,length=247249719>
+##contig=<ID=chr2,length=242951149>
+##contig=<ID=chr3,length=199501827>
+##contig=<ID=chr4,length=191273063>
+##contig=<ID=chr5,length=180857866>
+##contig=<ID=chr6,length=170899992>
+##contig=<ID=chr7,length=158821424>
+##contig=<ID=chr8,length=146274826>
+##contig=<ID=chr9,length=140273252>
+##contig=<ID=chr10,length=135374737>
+##contig=<ID=chr11,length=134452384>
+##contig=<ID=chr12,length=132349534>
+##contig=<ID=chr13,length=114142980>
+##contig=<ID=chr14,length=106368585>
+##contig=<ID=chr15,length=100338915>
+##contig=<ID=chr16,length=88827254>
+##contig=<ID=chr17,length=78774742>
+##contig=<ID=chr18,length=76117153>
+##contig=<ID=chr19,length=63811651>
+##contig=<ID=chr20,length=62435964>
+##contig=<ID=chr21,length=46944323>
+##contig=<ID=chr22,length=49691432>
+##contig=<ID=chrX,length=154913754>
+##contig=<ID=chrY,length=57772954>
+##contig=<ID=chrM,length=16571>
+##bcftools_concatVersion=1.3.1+htslib-1.3.1
+##bcftools_concatCommand=concat -a -o delly/simulated.orig.INDEL.bcf delly/simulated.orig.DEL.bcf delly/simulated.orig.INS.bcf
+##bcftools_annotateVersion=1.3.1+htslib-1.3.1
+##bcftools_annotateCommand=annotate -Ob -o external-fixed/simulated-delly.bcf -h resources/empty_header.txt delly/simulated.orig.INDEL.bcf
+##bcftools_viewVersion=1.3.1+htslib-1.3.1
+##bcftools_viewCommand=view -Ob external-fixed/simulated-delly.bcf chr1
+##INFO=<ID=PROB_GERMLINE,Number=A,Type=Float,Description="PHRED-scaled probability for germline variant">
+##INFO=<ID=PROB_SOMATIC,Number=A,Type=Float,Description="PHRED-scaled probability for somatic variant">
+##INFO=<ID=PROB_ABSENT,Number=A,Type=Float,Description="PHRED-scaled probability for absent variant">
+##INFO=<ID=CASE_AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency in case sample.">
+##INFO=<ID=CONTROL_AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency in control sample.">
+##bcftools_concatCommand=concat -Ov chrom-calls/chr1/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr2/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr3/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr4/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr5/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr6/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr7/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr8/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr9/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr10/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr11/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr12/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr13/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr14/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr15/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr16/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr17/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr18/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr19/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr20/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr21/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chr22/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chrM/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chrX/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf chrom-calls/chrY/simulated-delly.orig.flat+strict-len+adjst-mapq-purity0.75-secondaryFalse-fragmentsTrue.bcf
+##INFO=<ID=MATCHING,Number=A,Type=Integer,Description="For each alternative allele, -1 if it does not match a variant in another VCF/BCF. If it matches a variant, an id i>=0 is points to the i-th variant in the VCF/BCF (counting each alternative allele separately). For indels, matching is fuzzy: distance of centres <= 50, difference of lengths <= 10">
+##rust-bio-tools=0.1.1
+##rust-bio-tools-subcommand=vcf-match
+##bcftools_viewVersion=1.4.1+htslib-1.4.1
+##bcftools_viewCommand=view -h calls.matched.bcf; Date=Sat Nov 11 18:07:34 2017
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Cancer80	Control
+chr1	50906	DEL00000000	CAAAGTGAGGCAGGCAAGATGCTTTGTCAACTGCCTGGATGGAAT	C	0	PASS	PRECISE;SVTYPE=DEL;SVMETHOD=EMBL.DELLYv0.7.6;CHR2=chr1;END=50951;PE=0;MAPQ=37;CT=3to5;CIPOS=-2,2;CIEND=-2,2;INSLEN=0;HOMLEN=1;SR=10;SRQ=1;CONSENSUS=TATAATTATTTAATGATTACCAGAATTCGTTCAGTATGGCCAGCTCTGGTCGTCTCAAAAGGTTTCCATTTCATGGTAGCATTATGCAAAGTTCAAGACGTTTAATCAAGACCCTTCAC;CE=1.94625;PROB_GERMLINE=2.21848;PROB_SOMATIC=6.9897;PROB_ABSENT=6.9897;CASE_AF=0.4;CONTROL_AF=0.5;MATCHING=-1	GT:GL:GQ:FT:RCL:RC:RCR:CN:DR:DV:RR:RV	0/1:-1.49764,0,-29.6875:15:PASS:394:674:398:2:0:0:12:2	0/1:-5.99501,0,-12.7942:60:PASS:241:373:316:1:0:0:5:3
+chr1	52148	DEL00000001	T	<DEL>	.	LowQual	PRECISE;SVTYPE=DEL;SVMETHOD=EMBL.DELLYv0.7.6;CHR2=chr1;END=114549312;PE=9;MAPQ=15;CT=3to5;CIPOS=-7,7;CIEND=-7,7;INSLEN=0;HOMLEN=6;SR=10;SRQ=1;CONSENSUS=ATACACACACACACACACATATCTGTATATACAAATACACGTATAGCTTACATATATATATAGTATTCCGTGGCGTGTGTGTGTGTATGTGTGTATATATATATAAATATATA;CE=1.87082;PROB_GERMLINE=.;PROB_SOMATIC=.;PROB_ABSENT=.;CASE_AF=.;CONTROL_AF=.;MATCHING=-1	GT:GL:GQ:FT:RCL:RC:RCR:CN:DR:DV:RR:RV	0/1:-19.8233,0,-45.2761:10000:PASS:6004:44323964:0:14765:27:5:19:9	0/1:-9.98931,0,-25.8878:100:PASS:4649:33246123:0:14302:19:2:10:5
+chr1	947830	INS00000000	T	TTGTAGTCTGACCTGTGGTCTGAC	0	PASS	PRECISE;SVTYPE=INS;SVMETHOD=EMBL.DELLYv0.7.6;CHR2=chr1;END=947831;PE=0;MAPQ=60;CT=NtoN;CIPOS=-7,7;CIEND=-7,7;INSLEN=23;HOMLEN=6;SR=10;SRQ=1;CONSENSUS=CGTGCTGTGCCGGAGGCTGCAGCACACGGTGTCTTGTAGTCTGACCTGTGGTCTGACTGTGGTCCAACCTCATTCTCTGCTTCTCCGTCCCTGGCTCCCCAGCTGCATCTC;CE=1.89962;PROB_GERMLINE=10;PROB_SOMATIC=10;PROB_ABSENT=0.9691;CASE_AF=1;CONTROL_AF=1;MATCHING=-1	GT:GL:GQ:FT:RCL:RC:RCR:CN:DR:DV:RR:RV	1/1:-147.178,-14.4272,0:144:PASS:0:0:0:-1:0:0:0:48	1/1:-116.371,-11.7116,0:117:PASS:1:1:1:1:0:0:0:39


### PR DESCRIPTION
Changes `collect_prob_dist()` signature to take sets of `Event`s as input and adds tests for the function, based on variants and a header stolen from the `tests/resources/test_fdr_ev_1/calls.matched.bcf`.

The branch still doesn't pass on Travis, so I'm now trying via the pull request.

@johanneskoester Please do double check the changes I made, especially if the assumptions in the tests make sense (e.g. that the highest / only prob in the returned vectors is always in the last position of the returned vector).