### PR TITLE
add utils.rs function to filter by FDR thresholds

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -238,7 +238,7 @@ pub fn filter_by_threshold<E: Event>(
         }
 
         let variants = (utils::collect_variants(&mut record, false, false, None, false))?;
-        let mut events_probs = Vec::with_capacity(7);
+        let mut events_probs = Vec::with_capacity( variants.len() * tags.len() );
         for tag in &tags {
             if let Some(event_probs) = (record.info(tag.as_bytes()).float())? {
                 //tag present

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -238,7 +238,7 @@ pub fn filter_by_threshold<E: Event>(
         }
 
         let variants = (utils::collect_variants(&mut record, false, false, None, false))?;
-        let mut events_prob_sum = LogProb::ln_zero();
+        let mut events_probs = Vec::new();
         for tag in &tags {
             if let Some(event_probs) = (record.info(tag.as_bytes()).float())? {
                 //tag present
@@ -247,11 +247,12 @@ pub fn filter_by_threshold<E: Event>(
                         if !variant.is_type(vartype) || event_prob.is_nan() {
                             continue;
                         }
-                        events_prob_sum = events_prob_sum.ln_add_exp( LogProb::from( PHREDProb( *event_prob as f64 ) ) );
+                        events_probs.push( LogProb::from( PHREDProb( *event_prob as f64 ) ) );
                     }
                 }
             }
         }
+        let events_prob_sum = LogProb::ln_sum_exp(&events_probs);
         if events_prob_sum >= lp_threshold { out.write(&record)? };
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -238,7 +238,7 @@ pub fn filter_by_threshold<E: Event>(
         }
 
         let variants = (utils::collect_variants(&mut record, false, false, None, false))?;
-        let mut events_probs = Vec::new();
+        let mut events_probs = Vec::with_capacity(7);
         for tag in &tags {
             if let Some(event_probs) = (record.info(tag.as_bytes()).float())? {
                 //tag present

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -218,6 +218,18 @@ pub fn collect_prob_dist<E: Event>(
     Ok(prob_dist)
 }
 
+/// Filter a VCF record stream by a minimum threshold on the sum of
+/// posterior probabilities of a given set of Events. The threshold
+/// should be an informative false discovery rate (FDR) threshold,
+/// e.g. determined with the libprosic FDR control functionality.
+///
+/// # Arguments
+///
+/// * `calls` - BCF reader with libprosic calls
+/// * `threshold` - minimum threshold for the sum of posterior probabilities of the set of Events considered
+/// * `calls` - BCF writer for the filtered libprosic calls
+/// * `events` - the set of Events to filter on
+/// * `vartype` - the variant type to consider
 pub fn filter_by_threshold<E: Event>(
     calls: &bcf::Reader,
     threshold: &f64,


### PR DESCRIPTION
Trying to filter the BCF file based on compound false discovery rate (FDR) thresholds for `Event` sets that were generated by the `control-fdr` subcommand of prosolo, I realised that `bcftools` cannot easily filter on (useful) combinations of multiple PHRED scores. So I implemented this functionality as the backend of an `apply-fdr` subcommand for prosolo.

In the midterm, it might be useful to generate a separate CLI tool only for controlling the false discovery rate, because this should be agnostic of the libprosic CLI tool used for generating the `Event` probabilities. I created issue #16 to track this idea.

Also, could we make this a release 0.5.1, as it effectively closes a gap in the FDR functionality from version 0.5.0? Or would semantic versioning rather require a release 0.6.0?