### PR TITLE
abstract Event probabilities sum into function

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -288,7 +288,9 @@ mod tests {
         let test_file = "tests/resources/test_tags_prob_sum/overshoot.vcf";
         let mut overshoot_calls = bcf::Reader::from_path( test_file ).unwrap();
         let mut record = overshoot_calls.empty_record();
-        overshoot_calls.read(&mut record);
+        if let Err(e) = overshoot_calls.read(&mut record) {
+            panic!("BCF reading error: {}", e);
+        }
 
         // set up all alt events with names as in prosolo
         let alt_tags = [

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -362,7 +362,31 @@ mod tests {
 
     #[test]
     fn test_filter_by_threshold() {
-        //TODO: write a minimal test for this function
-    }
+        // TODO: make this test work with both thresholds, testing against expected_output files
+        /*
+        // set up test input
+        let test_file = "tests/resources/test_tags_prob_sum/overshoot.vcf";
+        let mut calls = bcf::Reader::from_path( test_file ).unwrap();
 
+        let threshold_1 = 0.1;
+        let threshold_2 = 0.00000000001;
+
+        let events = vec![
+            SimpleEvent { name: "ADO_TO_REF".to_owned() },
+            SimpleEvent { name: "ADO_TO_ALT".to_owned() },
+            SimpleEvent { name: "HOM_ALT".to_owned() },
+            SimpleEvent { name: "HET".to_owned() },
+            SimpleEvent { name: "ERR_REF".to_owned() }
+        ];
+
+        let snv = VariantType::SNV;
+
+        let header = bcf::Header::with_template(&calls.header());
+        let mut out = bcf::Writer::from_stdout(&header, false, false).unwrap();
+
+        filter_by_threshold(&mut calls, &threshold, &mut out, &events, &snv);
+
+        panic!("Just checking");
+        */
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -286,8 +286,8 @@ mod tests {
 
         // set up test input
         let test_file = "tests/resources/test_tags_prob_sum/overshoot.vcf";
-        let overshoot_calls = bcf::Reader::from_path( test_file ).unwrap();
-        let mut record = bcf::Record::new();
+        let mut overshoot_calls = bcf::Reader::from_path( test_file ).unwrap();
+        let mut record = overshoot_calls.empty_record();
         overshoot_calls.read(&mut record);
 
         // set up all alt events with names as in prosolo

--- a/tests/resources/test_tags_prob_sum/overshoot.vcf
+++ b/tests/resources/test_tags_prob_sum/overshoot.vcf
@@ -1,0 +1,15 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=chr1,length=247249719>
+##INFO=<ID=PROB_HOM_REF,Number=A,Type=Float,Description="PHRED-scaled probability for hom_ref variant">
+##INFO=<ID=PROB_ADO_TO_REF,Number=A,Type=Float,Description="PHRED-scaled probability for ADO_to_ref variant">
+##INFO=<ID=PROB_ADO_TO_ALT,Number=A,Type=Float,Description="PHRED-scaled probability for ADO_to_alt variant">
+##INFO=<ID=PROB_HOM_ALT,Number=A,Type=Float,Description="PHRED-scaled probability for hom_alt variant">
+##INFO=<ID=PROB_ERR_ALT,Number=A,Type=Float,Description="PHRED-scaled probability for err_alt variant">
+##INFO=<ID=PROB_HET,Number=A,Type=Float,Description="PHRED-scaled probability for het variant">
+##INFO=<ID=PROB_ERR_REF,Number=A,Type=Float,Description="PHRED-scaled probability for err_ref variant">
+##INFO=<ID=CASE_AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency in case sample.">
+##INFO=<ID=CONTROL_AF,Number=A,Type=Float,Description="Maximum a posteriori probability estimate of allele frequency in control sample.">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	single-cell.bam
+chr1	62976472	rs1168043	T	G	5682.93	PASS	PROB_HOM_REF=177.487;PROB_ADO_TO_REF=30.2547;PROB_ADO_TO_ALT=148.039;PROB_HOM_ALT=0.807449;PROB_ERR_ALT=2094.59;PROB_HET=12.1714;PROB_ERR_REF=9.66315;CASE_AF=1;CONTROL_AF=1	GT	1/1


### PR DESCRIPTION
* use numerically more stable `ln_sum_exp()` on vector with collection of Event probs

**Please don't merge, until the following is addressed:**

A second goal (further commits needed!) is to resolve numerical issues in summing up `Event` probabilities. @johanneskoester, would you have some recommendations regarding the following issue and my idea to resolve it?

I have now factored out the summing up of `Event`probabilities into a separate function that also is used in control-fdr and that first collects the probabilities at a site into a vector and the runs `ln_sum_exp()` on it. Nevertheless, control-fdr chokes on some sites, where the sum of the probabilities is slightly above of certain `Event`s is above one, e.g. the following line:

```
chr1	62976472	rs1168043	T	G	5682.93	PASS	AN=2;AC=2;PROB_HOM_REF=177.487;PROB_ADO_TO_REF=30.2547;PROB_ADO_TO_ALT=148.039;PROB_HOM_ALT=0.807449;PROB_ERR_ALT=2094.59;PROB_HET=12.1714;PROB_ERR_REF=9.66315;CASE_AF=1;CONTROL_AF=1	GT	1/1
```

If I sum up all `Event`s indicating the presence of an alternative allele (`ADO_TO_REF + ADO_TO_ALT + HOM_ALT + HET + ERR_REF`) with the following expression in `gnome-calculator` (which I assume suffers from similar numerical issues):
```
10^(-30,2547/10) + 10^(-148,039/10) + 10^(-0,807449/10) + 10^(-12,1714/10) + 10^(-9,66315/10)
```

I get out: `1,00000045890689`

And this fails in the following line of `libprosic` code:
https://github.com/PROSIC/libprosic/blob/1664d33cd43fd476275a06a913a38285f960f30a/src/estimation/fdr/ev.rs#L47

Which eventually triggers this panic (where the `p` passed down into this is in natural log space and thus a probability <= 1 should be `p <= 0`):
https://github.com/rust-bio/rust-bio/blob/76726e94a2cde8fb7a227ac60a4cb9bc6a9f62e8/src/stats/probs/mod.rs#L31

I think, we'll have to include an `epsilon` somewhere, to allow for such slight overshoots in probability sums, and I currently have three alternative ideas where to implement this -- the first two would be in `rust-bio`, the last right here in `libprosic`:

1. Ensure, that a `LogProb` is always `<= 0` upon construction of any `LogProb`, offering the standard existing constructor(s), but adding an assert there and then also adding alternative constructors that allow a certain `epsilon` and cut the probability into the correct range if it is outside but within the `epsilon` range.
2. Create an alternative `ln_one_minus_exp()` where we implement the `epsilon` that allows to move such slight overshoots onto the limits of the probability range.
3. Implement such an `epsilon` check and cut in `libprosic`, e.g. in `collect_prob_dist()` right here:
https://github.com/PROSIC/libprosic/blob/1664d33cd43fd476275a06a913a38285f960f30a/src/utils.rs#L231-L232

Is this reasonably clear? Any thoughts?