### PR TITLE
move from rustc-serialize dep to csv 1.0.0-beta.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "GPL-3.0"
 
 [dependencies]
-bio = "0.14"
+bio = "0.15"
 log = "0.3.*"
 rust-htslib = "0.13"
 GSL = "0.4.*"
@@ -20,9 +20,11 @@ ordered-float = "0.5"
 ndarray = "0.6"
 flame = { version = "^0.1.2", optional = true }
 flamer = { version = "^0.1.2", optional = true }
-rustc-serialize = "0.3"
 quick-error = "1.2"
-csv = "0.15"
+
+serde = "1"
+serde_derive = "1"
+csv = "1.0.0-beta.5"
 lazy_static = "0.2"
 statrs = "0.6.*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "GPL-3.0"
 
 [dependencies]
-bio = "0.15"
+bio = "0.16"
 log = "0.3.*"
 rust-htslib = "0.13"
 GSL = "0.4.*"

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -144,9 +144,9 @@ pub fn call<A, B, P, M, R, W, X, F>(
     };
 
     let mut outobs = if let Some(f) = outobs {
-        let mut writer = try!(csv::Writer::from_file(f)).delimiter(b'\t');
+        let mut writer = try!(csv::WriterBuilder::new().delimiter(b'\t').from_path(f) );
         // write header for observations
-        writer.write(
+        writer.write_record(
             ["chrom", "pos", "allele", "sample", "prob_mapping",
              "prob_alt", "prob_ref", "prob_mismapped", "evidence"].iter()
          )?;
@@ -179,10 +179,10 @@ pub fn call<A, B, P, M, R, W, X, F>(
                 for (i, pileup) in pileups.iter().enumerate() {
                     if let &Some(ref pileup) = pileup {
                         for obs in pileup.case_observations() {
-                            outobs.encode((chrom, record.pos(), i, "case", obs))?;
+                            outobs.serialize((chrom, record.pos(), i, "case", obs))?;
                         }
                         for obs in pileup.control_observations() {
-                            outobs.encode((chrom, record.pos(), i, "control", obs))?;
+                            outobs.serialize((chrom, record.pos(), i, "control", obs))?;
                         }
                     }
                 }

--- a/src/estimation/effective_mutation_rate.rs
+++ b/src/estimation/effective_mutation_rate.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use model::AlleleFreq;
 
 
-#[derive(Debug, RustcDecodable, RustcEncodable)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Estimate {
     pub observations: Vec<(f64, u64)>,
     pub intercept: f64,

--- a/src/estimation/fdr/bh.rs
+++ b/src/estimation/fdr/bh.rs
@@ -39,14 +39,14 @@ pub fn control_fdr<E: Event, W: io::Write>(
     writer: &mut W,
     events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
-    let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
-    try!(writer.write(["FDR", "max-prob"].into_iter()));
+    let mut writer = csv::WriterBuilder::new().delimiter(b'\t').from_writer(writer);
+    try!(writer.write_record(["FDR", "max-prob"].into_iter()));
 
     let null_dist = utils::collect_prob_dist(null_calls, events, vartype)?;
 
     if null_dist.is_empty() {
         for &alpha in &ALPHAS {
-            writer.write([&format!("{}", alpha), ""].iter())?;
+            writer.write_record([&format!("{}", alpha), ""].iter())?;
         }
         return Ok(());
     }
@@ -71,7 +71,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
                 break;
             }
         }
-        writer.encode(&record)?;
+        writer.serialize(&record)?;
     }
     writer.flush()?;
 

--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -31,14 +31,14 @@ pub fn control_fdr<E: Event, W: io::Write>(
     writer: &mut W,
     events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
-    let mut writer = csv::Writer::from_writer(writer).delimiter(b'\t');
-    try!(writer.write(["FDR", "max-prob"].into_iter()));
+    let mut writer = csv::WriterBuilder::new().delimiter(b'\t').from_writer(writer);
+    try!(writer.write_record(["FDR", "max-prob"].into_iter()));
 
     let prob_dist = utils::collect_prob_dist(calls, events, vartype)?;
 
     if prob_dist.is_empty() {
         for &alpha in &ALPHAS {
-            writer.write([&format!("{}", alpha), ""].iter())?;
+            writer.write_record([&format!("{}", alpha), ""].iter())?;
         }
         return Ok(());
     }
@@ -54,7 +54,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
         for i in (0..fdrs.len()).rev() {
             if fdrs[i] <= ln_alpha && (i == 0 || pep_dist[i] != pep_dist[i - 1]) {
                 let pep = pep_dist[i];
-                writer.encode(&Record {
+                writer.serialize(&Record {
                     alpha: alpha,
                     gamma: PHREDProb::from(pep.ln_one_minus_exp())
                 })?;

--- a/src/estimation/fdr/mod.rs
+++ b/src/estimation/fdr/mod.rs
@@ -1,3 +1,4 @@
+use csv;
 use bio::stats::PHREDProb;
 
 pub mod bh;
@@ -36,7 +37,7 @@ pub const ALPHAS: [f64; 28] = [
 ];
 
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct Record {
     alpha: f64,
     gamma: PHREDProb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ extern crate approx;
 extern crate rusty_machine;
 extern crate ordered_float;
 extern crate ndarray;
-extern crate rustc_serialize;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 #[macro_use]
 extern crate quick_error;
 extern crate csv;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -755,10 +755,9 @@ mod tests {
 
     fn setup_example(path: &str, deletion_factor: f64, insertion_factor: f64) -> (Vec<Observation>, Vec<Observation>, PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::TumorNormalModel>) {
         let mut reader = csv::ReaderBuilder::new().has_headers(true).delimiter(b'\t').from_path(path).expect("error reading example");
-        let mut rows = reader.deserialize();
         let mut case_obs = vec![];
         let mut control_obs = vec![];
-        if let Some(row) = rows.next() {
+        for row in reader.deserialize() {
             let record: Row = row.unwrap();
             let ev = recode_evidence(record.evidence);
             let obs = Observation {
@@ -773,8 +772,6 @@ mod tests {
                 "control" => control_obs.push(obs),
                 _ => panic!("unknown sample type: neither case nor control")
             }
-        } else {
-            panic!("expected at least one record but got none")
         }
 
         let insert_size = InsertSize{ mean: 312.0, sd: 15.0 };
@@ -825,10 +822,9 @@ mod tests {
     #[allow(dead_code)]
     fn setup_example_flat(path: &str) -> (Vec<Observation>, Vec<Observation>, PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::FlatTumorNormalModel>) {
         let mut reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(path).expect("error reading example");
-        let mut rows = reader.deserialize();
         let mut case_obs = vec![];
         let mut control_obs = vec![];
-        if let Some(row) = rows.next() {
+        for row in reader.deserialize() {
             let record: Row = row.unwrap();
             let ev = recode_evidence(record.evidence);
             let obs = Observation {
@@ -843,8 +839,6 @@ mod tests {
                 "control" => control_obs.push(obs),
                 _ => panic!("unknown sample type: neither case nor control")
             }
-        } else {
-            panic!("expected at least one record but got none")
         }
 
         let insert_size = InsertSize{ mean: 312.0, sd: 15.0 };
@@ -896,6 +890,7 @@ mod tests {
     #[test]
     fn test_example2() {
         let (case_obs, control_obs, model) = setup_example("tests/example2.obs.txt", 0.01, 0.03);
+        println!("{:?}", case_obs);
 
         let tumor_all = ContinuousAlleleFreqs::inclusive( 0.0..1.0 );
         let tumor_alt = ContinuousAlleleFreqs::inclusive( 0.05..1.0 );

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -734,8 +734,8 @@ mod tests {
     }
 
     fn setup_example(path: &str, deletion_factor: f64, insertion_factor: f64) -> (Vec<Observation>, Vec<Observation>, PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::TumorNormalModel>) {
-        let mut reader = csv::Reader::from_file(path).expect("error reading example").delimiter(b'\t');
-        let obs = reader.decode().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
+        let mut reader = csv::ReaderBuilder::new().has_headers(true).delimiter(b'\t').from_path(path).expect("error reading example");
+        let obs = reader.deserialize().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
         let groups = obs.into_iter().group_by(|&(_, _, _, ref sample, _)| {
             sample == "case"
         });
@@ -794,8 +794,8 @@ mod tests {
 
     #[allow(dead_code)]
     fn setup_example_flat(path: &str) -> (Vec<Observation>, Vec<Observation>, PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::FlatTumorNormalModel>) {
-        let mut reader = csv::Reader::from_file(path).expect("error reading example").delimiter(b'\t');
-        let obs = reader.decode().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
+        let mut reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(path).expect("error reading example");
+        let obs = reader.deserialize().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
         let groups = obs.into_iter().group_by(|&(_, _, _, ref sample, _)| {
             sample == "case"
         });

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -160,7 +160,7 @@ impl RecordBuffer {
 
 
 /// An observation for or against a variant.
-#[derive(Clone, Debug, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Observation {
     /// Posterior probability that the read/read-pair has been mapped correctly (1 - MAPQ).
     pub prob_mapping: LogProb,
@@ -189,7 +189,7 @@ impl Observation {
 /// Types of evidence that lead to an observation.
 /// The contained information is intended for debugging and will be printed together with
 /// observations.
-#[derive(Clone, Debug, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Evidence {
     /// Insert size of fragment
     InsertSize(String),
@@ -609,8 +609,8 @@ mod tests {
 
 
     fn read_observations(path: &str) -> Vec<Observation> {
-        let mut reader = csv::Reader::from_file(path).expect("error reading example").delimiter(b'\t');
-        let obs = reader.decode().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
+        let mut reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(path).expect("error reading example");
+        let obs = reader.deserialize().collect::<Result<Vec<(String, u32, u32, String, Observation)>, _>>().unwrap();
         let groups = obs.into_iter().group_by(|&(_, _, _, ref sample, _)| {
             sample == "case"
         });

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -630,9 +630,8 @@ mod tests {
 
     fn read_observations(path: &str) -> Vec<Observation> {
         let mut reader = csv::ReaderBuilder::new().delimiter(b'\t').from_path(path).expect("error reading example");
-        let mut rows = reader.deserialize();
         let mut case_obs = vec![];
-        if let Some(row) = rows.next() {
+        for row in reader.deserialize() {
             let record: Row = row.unwrap();
             if record.sample == "case" {
                 let ev = recode_evidence(record.evidence);
@@ -645,8 +644,6 @@ mod tests {
                 };
                 case_obs.push(obs)
             }
-        } else {
-            panic!("expected at least one record but got none")
         }
         case_obs
     }


### PR DESCRIPTION
This mirrors an update in `rust-bio 0.15` compared to `rust-bio 0.14` (I will need this update and actually an update to the next future release of `rust-bio` to enable the new `cap_numerical_overshoot()` function for `LogProb`s from `rust-bio` here in `libprosic`).

@johanneskoester:
While this branch compiles properly, 4 tests fail with a FloatParsingError on field 8 of the first record in the observation csv files example[2347].obs.txt in the new csv function `deserialize()` (<https://docs.rs/csv/1.0.0-beta.5/csv/struct.Reader.html#method.deserialize>).
Any ideas what might have changed in comparison to the `decode()` function in csv 0.15.0 (<https://docs.rs/csv/0.15.0/csv/struct.Reader.html#method.decode>)? It sounds like something to do with the `collect()` into the `Observation` `struct`, especially the `Evidence` `enum` in it, but the above cited documentation doesn't indicate that any of this shouldn't work, so I'm giving up for now -- the only alternative I would currently see would be to follow the examples for the new `deserialize()` function that would treat each row/record separately and manually add each to one of two collections `control_obs` or `case_obs`, but that doesn't seem elegant...