### PR TITLE
quick patch (omit double header for FDR thresholds)

### DIFF
--- a/src/estimation/fdr/bh.rs
+++ b/src/estimation/fdr/bh.rs
@@ -39,7 +39,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
     writer: &mut W,
     events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
-    let mut writer = csv::WriterBuilder::new().delimiter(b'\t').from_writer(writer);
+    let mut writer = csv::WriterBuilder::new().has_headers(false).delimiter(b'\t').from_writer(writer);
     try!(writer.write_record(["FDR", "max-prob"].into_iter()));
 
     let null_dist = utils::collect_prob_dist(null_calls, events, vartype)?;

--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -31,7 +31,7 @@ pub fn control_fdr<E: Event, W: io::Write>(
     writer: &mut W,
     events: &[E],
     vartype: &model::VariantType) -> Result<(), Box<Error>> {
-    let mut writer = csv::WriterBuilder::new().delimiter(b'\t').from_writer(writer);
+    let mut writer = csv::WriterBuilder::new().has_headers(false).delimiter(b'\t').from_writer(writer);
     try!(writer.write_record(["FDR", "max-prob"].into_iter()));
 
     let prob_dist = utils::collect_prob_dist(calls, events, vartype)?;

--- a/src/estimation/fdr/mod.rs
+++ b/src/estimation/fdr/mod.rs
@@ -1,4 +1,3 @@
-use csv;
 use bio::stats::PHREDProb;
 
 pub mod bh;


### PR DESCRIPTION
I found a little glitch from my downstream tests in prosolo: The new csv serializer automatically outputs the header automatically, based on field names. With the manual header output in our case, we got a double header and this patch restores previous behaviour. Should merge this before PR #22, which should be rebased after this is merged.