### PR TITLE
Unpack and reuse cigar

### DIFF
--- a/src/model/evidence/fragments.rs
+++ b/src/model/evidence/fragments.rs
@@ -51,8 +51,8 @@ pub fn n_fragment_positions(
 /// * `left` - left read of the pair
 /// * `right` - right read of the pair
 pub fn estimate_insert_size(left: &bam::Record, right: &bam::Record) -> Result<u32, Box<Error>> {
-    let left_cigar = left.cigar();
-    let right_cigar = right.cigar();
+    let left_cigar = left.cigar().unwrap();
+    let right_cigar = right.cigar().unwrap();
 
     let aln = |rec: &bam::Record, cigar| -> Result<(u32, u32), Box<Error>> {
         Ok((

--- a/src/model/evidence/observation.rs
+++ b/src/model/evidence/observation.rs
@@ -264,10 +264,10 @@ impl Common {
         match variant {
             &Variant::Deletion(_) | &Variant::Insertion(_) => {
                 for rec in valid_records() {
-                    let cigar = rec.cigar();
+                    let cigar = rec.cigar().unwrap();
 
                     let overlap = Overlap::new(
-                        rec, &cigar, start, variant, true
+                        rec, cigar, start, variant, true
                     )?;
 
                     if overlap.is_none() {
@@ -286,7 +286,7 @@ impl Common {
 
                     // record indel operations
                     let mut qpos = 0;
-                    for c in &cigar {
+                    for c in cigar {
                         match c {
                             &Cigar::Del(l) => {
                                 if let &Variant::Deletion(m) = variant {

--- a/src/model/evidence/reads.rs
+++ b/src/model/evidence/reads.rs
@@ -636,9 +636,10 @@ mod tests {
 
         let vpos = 4;
         let variant = model::Variant::None;
-        for (i, rec) in records.iter().enumerate() {
+        for (i, mut rec) in records.into_iter().enumerate() {
+            rec.unpack_cigar();
             println!("{}", str::from_utf8(rec.qname()).unwrap());
-            if let Ok( Some( (prob_ref, prob_alt) ) ) = prob_none(rec, &rec.cigar(), vpos, &variant, &ref_seq) {
+            if let Ok( Some( (prob_ref, prob_alt) ) ) = prob_none(&rec, rec.cigar().unwrap(), vpos, &variant, &ref_seq) {
                 println!("{:?}", rec.cigar());
                 println!("Pr(ref)={} Pr(alt)={}", (*prob_ref).exp(), (*prob_alt).exp() );
                 assert_relative_eq!( (*prob_ref).exp(), probs_ref[i], epsilon = eps[i]);
@@ -717,9 +718,10 @@ mod tests {
 
         let vpos = 5;
         let variant = model::Variant::SNV(b'G');
-        for (i, rec) in records.iter().enumerate() {
+        for (i, mut rec) in records.into_iter().enumerate() {
+            rec.unpack_cigar();
             println!("{}", str::from_utf8(rec.qname()).unwrap());
-            if let Ok( Some( (prob_ref, prob_alt) ) ) = prob_snv(rec, &rec.cigar(), vpos, &variant, &ref_seq) {
+            if let Ok( Some( (prob_ref, prob_alt) ) ) = prob_snv(&rec, rec.cigar().unwrap(), vpos, &variant, &ref_seq) {
                 println!("{:?}", rec.cigar());
                 println!("Pr(ref)={} Pr(alt)={}", (*prob_ref).exp(), (*prob_alt).exp() );
                 assert_relative_eq!( (*prob_ref).exp(), probs_ref[i], epsilon = eps[i]);

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -761,9 +761,10 @@ mod tests {
         // variant (obtained via bcftools)
         let start = 546;
         let variant = model::Variant::Insertion(b"GCATCCTGCG".to_vec());
-        for (i, rec) in records.iter().enumerate() {
+        for (i, mut rec) in records.into_iter().enumerate() {
+            rec.unpack_cigar();
             println!("{}", str::from_utf8(rec.qname()).unwrap());
-            let (prob_ref, prob_alt) = sample.indel_read_evidence.borrow_mut().prob(rec, rec.cigar().unwrap(), start, &variant, &ref_seq).unwrap();
+            let (prob_ref, prob_alt) = sample.indel_read_evidence.borrow_mut().prob(&rec, rec.cigar().unwrap(), start, &variant, &ref_seq).unwrap();
             println!("Pr(ref)={} Pr(alt)={}", *prob_ref, *prob_alt);
             println!("{:?}", rec.cigar());
             assert_relative_eq!(*prob_ref, probs_ref[i], epsilon=0.1);


### PR DESCRIPTION
We unpack the cigar in the ReadBuffer. This way, it happens only once, instead of multiple times, e.g. for subsequent variants that share reads with the previous buffer window.