### PR TITLE
Likelihood cache

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -497,12 +497,6 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         if self.marginal_prob.get().is_none() {
             debug!("Calculating marginal probability.");
 
-            let case_likelihood = |af_case: AlleleFreq, af_control: Option<AlleleFreq>| {
-                self.case_likelihood(af_case, af_control)
-            };
-            let control_likelihood = |af_control: AlleleFreq, af_case: Option<AlleleFreq>| {
-                self.control_likelihood(af_control, af_case)
-            };
             let p = self.prior_model.marginal_prob(self);
             debug!("Marginal probability: {}.", p.exp());
 
@@ -513,13 +507,6 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
     }
 
     pub fn joint_prob(&self, af_case: &A, af_control: &B) -> LogProb {
-        let case_likelihood = |af_case: AlleleFreq, af_control: Option<AlleleFreq>| {
-            self.case_likelihood(af_case, af_control)
-        };
-        let control_likelihood = |af_control: AlleleFreq, af_case: Option<AlleleFreq>| {
-            self.control_likelihood(af_control, af_case)
-        };
-
         let p = self.prior_model.joint_prob(&self, af_case, af_control);
         p
     }
@@ -533,13 +520,6 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
     }
 
     pub fn map_allele_freqs(&mut self) -> (AlleleFreq, AlleleFreq) {
-        let case_likelihood = |af_case: AlleleFreq, af_control: Option<AlleleFreq>| {
-            self.case_likelihood(af_case, af_control)
-        };
-        let control_likelihood = |af_control: AlleleFreq, af_case: Option<AlleleFreq>| {
-            self.control_likelihood(af_control, af_case)
-        };
-
         self.prior_model.map(&self)
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -460,8 +460,8 @@ pub struct PairPileup<'a, A, B, P> where
     case_sample_model: likelihood::LatentVariableModel,
     control_sample_model: likelihood::LatentVariableModel,
     // these two caches are useful for PairModels where case and control are independent of each other and Events are just combinations of across the two axes, as e.g. in the single-cell-bulk model
-    case_likelihood_cache: &'a mut BTreeMap<AlleleFreq, LogProb>,
-    control_likelihood_cache: &'a mut BTreeMap<AlleleFreq, LogProb>,
+    case_likelihood_cache: Cell<BTreeMap<AlleleFreq, LogProb>>,
+    control_likelihood_cache: Cell<BTreeMap<AlleleFreq, LogProb>>,
     variant: Variant,
     a: PhantomData<A>,
     b: PhantomData<B>
@@ -481,13 +481,13 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         PairPileup {
             case: case,
             control: control,
-            case_likelihood_cache: &mut BTreeMap::new(),
-            control_likelihood_cache: &mut BTreeMap::new(),
             marginal_prob: Cell::new(None),
             variant: variant,
             prior_model: prior_model,
             case_sample_model: case_sample_model,
             control_sample_model: control_sample_model,
+            case_likelihood_cache: Cell::new(BTreeMap::new()),
+            control_likelihood_cache: Cell::new(BTreeMap::new()),
             a: PhantomData,
             b: PhantomData
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -447,7 +447,7 @@ impl<A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairCaller<A, B
 
 
 /// Pileup of observations associated with marginal probability.
-pub struct PairPileup<'a, A, B, P> where
+pub struct PairPileup<'a, A, B, P: ?Sized> where
     A: AlleleFreqs,
     B: AlleleFreqs,
     P: 'a + priors::PairModel<A, B>

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -493,7 +493,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         }
     }
 
-    fn marginal_prob(&mut self) -> LogProb {
+    fn marginal_prob(&self) -> LogProb {
         if self.marginal_prob.get().is_none() {
             debug!("Calculating marginal probability.");
 
@@ -503,7 +503,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
             let control_likelihood = |af_control: AlleleFreq, af_case: Option<AlleleFreq>| {
                 self.control_likelihood(af_control, af_case)
             };
-            let p = self.prior_model.marginal_prob(&mut self);
+            let p = self.prior_model.marginal_prob(self);
             debug!("Marginal probability: {}.", p.exp());
 
             self.marginal_prob.set(Some(p));
@@ -512,7 +512,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         self.marginal_prob.get().unwrap()
     }
 
-    pub fn joint_prob(&mut self, af_case: &A, af_control: &B) -> LogProb {
+    pub fn joint_prob(&self, af_case: &A, af_control: &B) -> LogProb {
         let case_likelihood = |af_case: AlleleFreq, af_control: Option<AlleleFreq>| {
             self.case_likelihood(af_case, af_control)
         };
@@ -520,12 +520,12 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
             self.control_likelihood(af_control, af_case)
         };
 
-        let p = self.prior_model.joint_prob(af_case, af_control, &mut self);
+        let p = self.prior_model.joint_prob(&self, af_case, af_control);
         p
     }
 
     /// Calculate posterior probability of given allele frequencies.
-    pub fn posterior_prob(&mut self, af_case: &A, af_control: &B) -> LogProb {
+    pub fn posterior_prob(&self, af_case: &A, af_control: &B) -> LogProb {
         let p = self.joint_prob(af_case, af_control);
         let marginal = self.marginal_prob();
         let prob = p - marginal;
@@ -540,19 +540,19 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
             self.control_likelihood(af_control, af_case)
         };
 
-        self.prior_model.map(&mut self)
+        self.prior_model.map(&self)
     }
 
     fn case_likelihood(&mut self, af_case: AlleleFreq, af_control: Option<AlleleFreq>) -> LogProb {
         // no af_control given, because case and control are independent
         if af_control.is_none() {
             // check whether likelihood is already cached
-            if let Some(p) = self.case_likelihood_cache.get(&af_case) {
+            if let Some(p) = self.case_likelihood_cache.get_mut().get(&af_case) {
                 *p
             // compute likelihood and cache it
             } else {
                 let p = self.case_sample_model.likelihood_pileup(&self.case, af_case, af_control);
-                self.case_likelihood_cache.insert(af_case, p);
+                self.case_likelihood_cache.get_mut().insert(af_case, p);
                 p
             }
         // cache cannot be used
@@ -565,12 +565,12 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         // no af_control given, because case and control are independent
         if af_case.is_none() {
             // check whether likelihood is already cached
-            if let Some(p) = self.control_likelihood_cache.get(&af_control) {
+            if let Some(p) = self.control_likelihood_cache.get_mut().get(&af_control) {
                 *p
             // compute likelihood and cache it
             } else {
                 let p = self.control_sample_model.likelihood_pileup(&self.control, af_control, af_case);
-                self.control_likelihood_cache.insert(af_control, p);
+                self.control_likelihood_cache.get_mut().insert(af_control, p);
                 p
             }
         // cache cannot be used

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -51,7 +51,7 @@ pub trait PairModel<A: AlleleFreqs, B: AlleleFreqs> {
     /// Calculate joint probability of prior with likelihoods for given allele frequency ranges.
     fn joint_prob(
         &self,
-        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
+        pileup: &PairPileup<A, B, Self>,
         af1: &A,
         af2: &B,
     ) -> LogProb;
@@ -59,13 +59,13 @@ pub trait PairModel<A: AlleleFreqs, B: AlleleFreqs> {
     /// Calculate marginal probability.
     fn marginal_prob(
         &self,
-        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
+        pileup: &PairPileup<A, B, Self>,
     ) -> LogProb;
 
     /// Calculate maximum a posteriori probability estimate of allele frequencies.
     fn map(
         &self,
-        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
+        pileup: &PairPileup<A, B, Self>,
     ) -> (AlleleFreq, AlleleFreq);
 
     /// Return allele frequency spectra.

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -1,9 +1,9 @@
 pub mod infinite_sites_neutral_variation;
 pub mod tumor_normal;
-pub mod single_cell_bulk;
+///pub mod single_cell_bulk;
 // TODO disable Tumor-Normal-Relapse model until i
 //pub mod tumor_normal_relapse;
-pub mod flat;
+///pub mod flat;
 pub mod normal;
 
 use bio::stats::LogProb;
@@ -12,10 +12,10 @@ use model::{Variant, AlleleFreqs, AlleleFreq};
 
 pub use priors::infinite_sites_neutral_variation::InfiniteSitesNeutralVariationModel;
 pub use priors::tumor_normal::TumorNormalModel;
-pub use priors::single_cell_bulk::SingleCellBulkModel;
+///pub use priors::single_cell_bulk::SingleCellBulkModel;
 //pub use priors::tumor_normal_relapse::TumorNormalRelapseModel;
-pub use priors::flat::FlatTumorNormalModel;
-pub use priors::flat::FlatNormalNormalModel;
+///pub use priors::flat::FlatTumorNormalModel;
+///pub use priors::flat::FlatNormalNormalModel;
 pub use model::PairPileup;
 
 /// A prior model of the allele frequency spectrum.
@@ -49,42 +49,24 @@ pub trait PairModel<A: AlleleFreqs, B: AlleleFreqs> {
     fn prior_prob(&self, af1: AlleleFreq, af2: AlleleFreq, variant: &Variant) -> LogProb;
 
     /// Calculate joint probability of prior with likelihoods for given allele frequency ranges.
-    fn joint_prob<L, O>(
+    fn joint_prob(
         &self,
+        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
         af1: &A,
         af2: &B,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+    ) -> LogProb;
 
     /// Calculate marginal probability.
-    fn marginal_prob<L, O>(
+    fn marginal_prob(
         &self,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
+    ) -> LogProb;
 
     /// Calculate maximum a posteriori probability estimate of allele frequencies.
-    fn map<L, O>(
+    fn map(
         &self,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> (AlleleFreq, AlleleFreq) where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+        pileup: &mut PairPileup<A, B, PairModel<A, B>>,
+    ) -> (AlleleFreq, AlleleFreq);
 
     /// Return allele frequency spectra.
     fn allele_freqs(&self) -> (&A, &B);

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -9,6 +9,7 @@ use model::{Variant, ContinuousAlleleFreqs, DiscreteAlleleFreqs, AlleleFreq};
 
 use priors::InfiniteSitesNeutralVariationModel;
 use priors::PairModel;
+use model::PairPileup;
 
 
 /// Tumor-normal prior model using ploidy, heterozygosity (in normal tissue) and tumor mutation rate
@@ -136,24 +137,18 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
         p
     }
 
-    fn joint_prob<L, O>(
+    fn joint_prob(
         &self,
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs>>,
         af_tumor: &ContinuousAlleleFreqs,
         af_normal: &DiscreteAlleleFreqs,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        _: usize,
-        _: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+    ) -> LogProb
     {
         let prob = LogProb::ln_sum_exp(&af_normal.iter().map(|&af_normal| {
             let density = |af_tumor| {
                 let af_tumor = AlleleFreq(af_tumor);
-                self.prior_prob(af_tumor, af_normal, variant) +
-                likelihood_tumor(af_tumor, Some(af_normal))
+                self.prior_prob(af_tumor, af_normal, pileup.variant) +
+                pileup.case_likelihood(af_tumor, Some(af_normal))
             };
 
             let p_tumor = if af_tumor.start == af_tumor.end {
@@ -161,7 +156,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
             } else {
                 LogProb::ln_simpsons_integrate_exp(&density, *af_tumor.start, *af_tumor.end, self.grid_points)
             };
-            let p_normal = likelihood_normal(af_normal, None);
+            let p_normal = pileup.control_likelihood(af_normal, None);
             println!("prior model probs: af={} {:?} {:?}", af_normal, p_tumor, p_normal);
             let prob = p_tumor + p_normal;
 
@@ -171,58 +166,38 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
         prob
     }
 
-    fn marginal_prob<L, O>(
+    fn marginal_prob(
         &self,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        n_obs_tumor: usize,
-        n_obs_normal: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs>>,
+    ) -> LogProb
     {
         let p = self.joint_prob(
+            pileup,
             self.allele_freqs().0,
             self.allele_freqs().1,
-            likelihood_tumor,
-            likelihood_normal,
-            variant,
-            n_obs_tumor,
-            n_obs_normal
         ).ln_add_exp(
             // add prob for allele frequency zero (the density is non-continuous there)
             self.joint_prob(
+                pileup,
                 &ContinuousAlleleFreqs::inclusive( 0.0..0.0 ),
                 &DiscreteAlleleFreqs::new(vec![AlleleFreq(0.0)]),
-                likelihood_tumor,
-                likelihood_normal,
-                variant,
-                n_obs_tumor,
-                n_obs_normal
             )
         );
         p
     }
 
-    fn map<L, O>(
+    fn map(
         &self,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        _: usize,
-        _: usize
-    ) -> (AlleleFreq, AlleleFreq) where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs>>,
+    ) -> (AlleleFreq, AlleleFreq)
     {
         let af_case = linspace(*self.allele_freqs_tumor.start, *self.allele_freqs_tumor.end, self.grid_points);
         let (_, (map_normal, map_tumor)) = self.allele_freqs_normal.iter().cartesian_product(af_case).minmax_by_key(
             |&(&af_normal, af_tumor)| {
                 let af_tumor = AlleleFreq(af_tumor);
-                let p = self.prior_prob(af_tumor, af_normal, variant) +
-                        likelihood_tumor(af_tumor, Some(af_normal)) +
-                        likelihood_normal(af_normal, None);
+                let p = self.prior_prob(af_tumor, af_normal, pileup.variant) +
+                        pileup.case_likelihood(af_tumor, Some(af_normal)) +
+                        pileup.control_likelihood(af_normal, None);
                 NotNaN::new(*p).expect("posterior probability is NaN")
             }
         ).into_option().expect("prior has empty allele frequency spectrum");


### PR DESCRIPTION
Hey @johanneskoester,

I'm stuck here, so I pushed my most promising current attempt. This is just trying to get the structure including the mutable likelihood cache to work in the `tumor_normal` model, so I currently commented out the `flat` and the `single-cell-bulk` model.

Having `PairPileup` in the signature of `PairModel` functions seems slightly circular to me, but the main problem I currently have is the compiler error I get about PairPileup not being `Sized`. Maybe you have a quick idea or insight to help me here?

thanks and cheers,
david