### PR TITLE
Likelihood caches via mutable pair pileup passing

### DIFF
--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -175,7 +175,7 @@ pub fn call<A, B, P, M, R, W, X, F>(
 
         // translate to header of the writer
         outbcf.translate(&mut record);
-        let pileups = pileups(
+        let mut pileups = pileups(
             &inbcf, &mut record, pair_model, &mut reference_buffer,
             omit_snvs, omit_indels, max_indel_len, exclusive_end
         )?;
@@ -200,8 +200,8 @@ pub fn call<A, B, P, M, R, W, X, F>(
             // write posterior probabilities
             let mut posterior_probs = Array::default((events.len(), pileups.len()));
             for (i, event) in events.iter().enumerate() {
-                for (j, pileup) in pileups.iter().enumerate() {
-                    let p = if let &Some(ref pileup) = pileup {
+                for (j, pileup) in pileups.iter_mut().enumerate() {
+                    let p = if let &mut Some(ref mut pileup) = pileup {
                         // use joint probability instead of posterior since we do the
                         // normalization below, turning joint probabilities into posteriors.
                         Some(pileup.joint_prob(&event.af_case, &event.af_control))
@@ -236,8 +236,8 @@ pub fn call<A, B, P, M, R, W, X, F>(
             // write allele frequency estimates
             let mut case_afs = Vec::with_capacity(pileups.len());
             let mut control_afs = Vec::with_capacity(pileups.len());
-            for pileup in &pileups {
-                if let &Some(ref pileup) = pileup {
+            for pileup in &mut pileups {
+                if let &mut Some(ref mut pileup) = pileup {
                     let (case_af, control_af) = pileup.map_allele_freqs();
                     case_afs.push(*case_af as f32);
                     control_afs.push(*control_af as f32);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -662,7 +662,7 @@ mod tests {
         }
 
         let model = setup_pairwise_test();
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             observations.clone(), observations.clone(),
             variant,
             &model.prior_model,
@@ -699,7 +699,7 @@ mod tests {
         }
 
         let model = setup_pairwise_test();
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             observations.clone(), vec![],
             variant,
             &model.prior_model,
@@ -744,7 +744,7 @@ mod tests {
         }
 
         let model = setup_pairwise_test();
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             observations.clone(), vec![],
             variant,
             &model.prior_model,
@@ -780,7 +780,7 @@ mod tests {
         }
 
         let model = setup_pairwise_test();
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             observations.clone(), observations.clone(),
             variant,
             &model.prior_model,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -537,12 +537,20 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         self.prior_model.map(&case_likelihood, &control_likelihood, &self.variant, self.case.len(), self.control.len())
     }
 
-    fn case_likelihood(&self, af_case: AlleleFreq, af_control: Option<AlleleFreq>) -> LogProb {
+    fn case_likelihood(
+        &self,
+        af_case: AlleleFreq,
+        af_control: Option<AlleleFreq>
+    ) -> LogProb {
         let p = self.case_sample_model.likelihood_pileup(&self.case, af_case, af_control);
         p
     }
 
-    fn control_likelihood(&self, af_control: AlleleFreq, af_case: Option<AlleleFreq>) -> LogProb {
+    fn control_likelihood(
+        &self,
+        af_control: AlleleFreq,
+        af_case: Option<AlleleFreq>
+    ) -> LogProb {
         let p = self.control_sample_model.likelihood_pileup(&self.control, af_control, af_case);
         p
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,6 +4,7 @@ use std::ops::{Range, Deref};
 use std::fmt::Debug;
 use std::error::Error;
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 
 use ordered_float::NotNaN;
 use itertools::Itertools;
@@ -458,6 +459,9 @@ pub struct PairPileup<'a, A, B, P> where
     prior_model: &'a P,
     case_sample_model: likelihood::LatentVariableModel,
     control_sample_model: likelihood::LatentVariableModel,
+    // these two caches are useful for PairModels where case and control are independent of each other and Events are just combinations of across the two axes, as e.g. in the single-cell-bulk model
+    case_likelihood_cache: BTreeMap<AlleleFreq, LogProb>,
+    control_likelihood_cache: BTreeMap<AlleleFreq, LogProb>,
     variant: Variant,
     a: PhantomData<A>,
     b: PhantomData<B>
@@ -482,6 +486,8 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
             prior_model: prior_model,
             case_sample_model: case_sample_model,
             control_sample_model: control_sample_model,
+            case_likelihood_cache: BTreeMap::new(),
+            control_likelihood_cache: BTreeMap::new(),
             a: PhantomData,
             b: PhantomData
         }

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -1,10 +1,10 @@
 pub mod infinite_sites_neutral_variation;
 pub mod tumor_normal;
-///pub mod single_cell_bulk;
+pub mod single_cell_bulk;
 // TODO disable Tumor-Normal-Relapse model until i
 //pub mod tumor_normal_relapse;
-///pub mod flat;
-///pub mod normal;
+pub mod flat;
+pub mod normal;
 
 use bio::stats::LogProb;
 
@@ -12,10 +12,10 @@ use model::{Variant, AlleleFreqs, AlleleFreq};
 
 pub use priors::infinite_sites_neutral_variation::InfiniteSitesNeutralVariationModel;
 pub use priors::tumor_normal::TumorNormalModel;
-///pub use priors::single_cell_bulk::SingleCellBulkModel;
+pub use priors::single_cell_bulk::SingleCellBulkModel;
 //pub use priors::tumor_normal_relapse::TumorNormalRelapseModel;
-///pub use priors::flat::FlatTumorNormalModel;
-///pub use priors::flat::FlatNormalNormalModel;
+pub use priors::flat::FlatTumorNormalModel;
+pub use priors::flat::FlatNormalNormalModel;
 pub use model::PairPileup;
 
 /// A prior model of the allele frequency spectrum.

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -1,10 +1,10 @@
 pub mod infinite_sites_neutral_variation;
 pub mod tumor_normal;
-pub mod single_cell_bulk;
+///pub mod single_cell_bulk;
 // TODO disable Tumor-Normal-Relapse model until i
 //pub mod tumor_normal_relapse;
-pub mod flat;
-pub mod normal;
+///pub mod flat;
+///pub mod normal;
 
 use bio::stats::LogProb;
 
@@ -12,10 +12,10 @@ use model::{Variant, AlleleFreqs, AlleleFreq};
 
 pub use priors::infinite_sites_neutral_variation::InfiniteSitesNeutralVariationModel;
 pub use priors::tumor_normal::TumorNormalModel;
-pub use priors::single_cell_bulk::SingleCellBulkModel;
+///pub use priors::single_cell_bulk::SingleCellBulkModel;
 //pub use priors::tumor_normal_relapse::TumorNormalRelapseModel;
-pub use priors::flat::FlatTumorNormalModel;
-pub use priors::flat::FlatNormalNormalModel;
+///pub use priors::flat::FlatTumorNormalModel;
+///pub use priors::flat::FlatNormalNormalModel;
 pub use model::PairPileup;
 
 /// A prior model of the allele frequency spectrum.
@@ -49,42 +49,24 @@ pub trait PairModel<A: AlleleFreqs, B: AlleleFreqs> {
     fn prior_prob(&self, af1: AlleleFreq, af2: AlleleFreq, variant: &Variant) -> LogProb;
 
     /// Calculate joint probability of prior with likelihoods for given allele frequency ranges.
-    fn joint_prob<L, O>(
+    fn joint_prob(
         &self,
         af1: &A,
         af2: &B,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+        pileup: &mut PairPileup<A, B, Self>,
+    ) -> LogProb;
 
     /// Calculate marginal probability.
-    fn marginal_prob<L, O>(
+    fn marginal_prob(
         &self,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+        pileup: &mut PairPileup<A, B, Self>,
+    ) -> LogProb;
 
     /// Calculate maximum a posteriori probability estimate of allele frequencies.
-    fn map<L, O>(
+    fn map(
         &self,
-        likelihood1: &L,
-        likelihood2: &O,
-        variant: &Variant,
-        n_obs1: usize,
-        n_obs2: usize
-    ) -> (AlleleFreq, AlleleFreq) where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb;
+        pileup: &mut PairPileup<A, B, Self>,
+    ) -> (AlleleFreq, AlleleFreq);
 
     /// Return allele frequency spectra.
     fn allele_freqs(&self) -> (&A, &B);

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -176,13 +176,13 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
         let p = self.joint_prob(
             self.allele_freqs().0,
             self.allele_freqs().1,
-            pileup,
+            pileup
         ).ln_add_exp(
             // add prob for allele frequency zero (the density is non-continuous there)
             self.joint_prob(
                 &ContinuousAlleleFreqs::inclusive( 0.0..0.0 ),
                 &DiscreteAlleleFreqs::new(vec![AlleleFreq(0.0)]),
-                pileup,
+                pileup
             )
         );
         p
@@ -253,7 +253,7 @@ mod tests {
         let tumor_obs = create_obs_vector(5, 0);
         let normal_obs = create_obs_vector(5, 0);
 
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             tumor_obs.clone(),
             normal_obs.clone(),
             variant.clone(),
@@ -285,7 +285,7 @@ mod tests {
         let tumor_obs = create_obs_vector(5, 0);
         let normal_obs = create_obs_vector(5, 0);
 
-        let pileup = PairPileup::new(
+        let mut pileup = PairPileup::new(
             tumor_obs.clone(),
             normal_obs.clone(),
             variant.clone(),

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -5,7 +5,7 @@ use itertools_num::linspace;
 use ordered_float::NotNaN;
 use bio::stats::{LogProb, Prob};
 
-use model::{Variant, ContinuousAlleleFreqs, DiscreteAlleleFreqs, AlleleFreq};
+use model::{Variant, ContinuousAlleleFreqs, DiscreteAlleleFreqs, AlleleFreq, PairPileup};
 
 use priors::InfiniteSitesNeutralVariationModel;
 use priors::PairModel;
@@ -136,32 +136,29 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
         p
     }
 
-    fn joint_prob<L, O>(
+    fn joint_prob(
         &self,
         af_tumor: &ContinuousAlleleFreqs,
         af_normal: &DiscreteAlleleFreqs,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        _: usize,
-        _: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, Self>,
+    ) -> LogProb
     {
         let prob = LogProb::ln_sum_exp(&af_normal.iter().map(|&af_normal| {
-            let density = |af_tumor| {
-                let af_tumor = AlleleFreq(af_tumor);
-                self.prior_prob(af_tumor, af_normal, variant) +
-                likelihood_tumor(af_tumor, Some(af_normal))
-            };
+            let p_tumor: LogProb;
+            {
+                let mut density = |af_tumor| {
+                    let af_tumor = AlleleFreq(af_tumor);
+                    self.prior_prob(af_tumor, af_normal, &pileup.variant) +
+                    pileup.case_likelihood(af_tumor, Some(af_normal))
+                };
 
-            let p_tumor = if af_tumor.start == af_tumor.end {
-                density(*af_tumor.start)
-            } else {
-                LogProb::ln_simpsons_integrate_exp(&density, *af_tumor.start, *af_tumor.end, self.grid_points)
-            };
-            let p_normal = likelihood_normal(af_normal, None);
+                p_tumor = if af_tumor.start == af_tumor.end {
+                    density(*af_tumor.start)
+                } else {
+                    LogProb::ln_simpsons_integrate_exp(density, *af_tumor.start, *af_tumor.end, self.grid_points)
+                };
+            }
+            let p_normal = pileup.control_likelihood(af_normal, None);
             println!("prior model probs: af={} {:?} {:?}", af_normal, p_tumor, p_normal);
             let prob = p_tumor + p_normal;
 
@@ -171,58 +168,38 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
         prob
     }
 
-    fn marginal_prob<L, O>(
+    fn marginal_prob(
         &self,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        n_obs_tumor: usize,
-        n_obs_normal: usize
-    ) -> LogProb where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, Self>,
+    ) -> LogProb
     {
         let p = self.joint_prob(
             self.allele_freqs().0,
             self.allele_freqs().1,
-            likelihood_tumor,
-            likelihood_normal,
-            variant,
-            n_obs_tumor,
-            n_obs_normal
+            pileup,
         ).ln_add_exp(
             // add prob for allele frequency zero (the density is non-continuous there)
             self.joint_prob(
                 &ContinuousAlleleFreqs::inclusive( 0.0..0.0 ),
                 &DiscreteAlleleFreqs::new(vec![AlleleFreq(0.0)]),
-                likelihood_tumor,
-                likelihood_normal,
-                variant,
-                n_obs_tumor,
-                n_obs_normal
+                pileup,
             )
         );
         p
     }
 
-    fn map<L, O>(
+    fn map(
         &self,
-        likelihood_tumor: &L,
-        likelihood_normal: &O,
-        variant: &Variant,
-        _: usize,
-        _: usize
-    ) -> (AlleleFreq, AlleleFreq) where
-        L: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb,
-        O: Fn(AlleleFreq, Option<AlleleFreq>) -> LogProb
+        pileup: &mut PairPileup<ContinuousAlleleFreqs, DiscreteAlleleFreqs, Self>,
+    ) -> (AlleleFreq, AlleleFreq)
     {
         let af_case = linspace(*self.allele_freqs_tumor.start, *self.allele_freqs_tumor.end, self.grid_points);
         let (_, (map_normal, map_tumor)) = self.allele_freqs_normal.iter().cartesian_product(af_case).minmax_by_key(
             |&(&af_normal, af_tumor)| {
                 let af_tumor = AlleleFreq(af_tumor);
-                let p = self.prior_prob(af_tumor, af_normal, variant) +
-                        likelihood_tumor(af_tumor, Some(af_normal)) +
-                        likelihood_normal(af_normal, None);
+                let p = self.prior_prob(af_tumor, af_normal, &pileup.variant) +
+                        pileup.case_likelihood(af_tumor, Some(af_normal)) +
+                        pileup.control_likelihood(af_normal, None);
                 NotNaN::new(*p).expect("posterior probability is NaN")
             }
         ).into_option().expect("prior has empty allele frequency spectrum");


### PR DESCRIPTION
This introduces two likelihood caches into `PairPileup`, to avoid calculating the same likelihoods multiple times. So far this is only implemented for the `TumorNormalModel`, to first make it work before applying it to the other models, as well.

@johanneskoester: I hope this is a cleaner restart compared to before. I have tried around a lot of things and this is closest to working. The compiler now chokes on the two following spots (each with a line ahead shown for context, relevant is the bottom line):

https://github.com/PROSIC/libprosic/blob/6cb3d6d0d6be1d17476cad5e53dfef6d8726f81e/src/call/pairwise.rs#L203-L204

https://github.com/PROSIC/libprosic/blob/6cb3d6d0d6be1d17476cad5e53dfef6d8726f81e/src/call/pairwise.rs#L239-L240

In the current code state, it throws:
```
error[E0596]: cannot borrow immutable borrowed content `*pileup` as mutable
   --> src/call/pairwise.rs:241:49
    |
240 |                 if let &Some(ref pileup) = pileup {
    |                              ---------- consider changing this to `ref mut pileup`
241 |                     let (case_af, control_af) = pileup.map_allele_freqs();
    |                                                 ^^^^^^ cannot borrow as mutable
```

If I follow the recommendation of adding `mut`, it instead complains:
```
error[E0596]: cannot borrow anonymous field `(pileup as serde::export::Some).0` of immutable binding as mutable
   --> src/call/pairwise.rs:240:30
    |
240 |                 if let &Some(ref mut pileup) = pileup {
    |                              ^^^^^^^^^^^^^^ cannot mutably borrow field of immutable binding

```

So as far as I understand it, it is some kind of serialization issue that makes `pileup` an anonymous field. But l can't get my head around what to do here -- make the binding mutable? the field non-anonymous?

Any suggestions?