### PR TITLE
Likelihood caches working

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -530,14 +530,13 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
     ) -> LogProb {
         // no af_control given, because case and control are independent
         if af_control.is_none() {
-            let l: LogProb;
+            // get likelihood if already cached
             if let Some(likelihood) = self.case_likelihood_cache.get(&af_case) {
-                // get likelihood if already cached
-                return *likelihood
-            } else {
-                // compute otherwise
-                l = self.case_sample_model.likelihood_pileup(&self.case, af_case, None);
+                return *likelihood;
             }
+            // compute otherwise
+            let l = self.case_sample_model.likelihood_pileup(&self.case, af_case, None);
+            // insert into cache before returning
             self.case_likelihood_cache.insert(af_case, l);
             l
         // cache cannot be used
@@ -553,15 +552,13 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
     ) -> LogProb {
         // no af_control given, because case and control are independent
         if af_case.is_none() {
-            let l: LogProb;
+            // get likelihood if already cached
             if let Some(likelihood) = self.control_likelihood_cache.get(&af_control) {
-                // get likelihood if already cached
-                return *likelihood
-            } else {
-                // compute otherwise
-                l = self.control_sample_model.likelihood_pileup(&self.control, af_control, None);
+                return *likelihood;
             }
-            //insert into cache before returning
+            // compute otherwise
+            let l = self.control_sample_model.likelihood_pileup(&self.control, af_control, None);
+            // insert into cache before returning
             self.control_likelihood_cache.insert(af_control, l);
             l
         // cache cannot be used

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -533,7 +533,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
                 // get likelihood if already cached
             *self.case_likelihood_cache.entry(af_case)
                 // compute and insert otherwise
-                .or_insert( self.case_sample_model.likelihood_pileup(&self.case, af_case, None) )
+                .or_insert_with( || self.case_sample_model.likelihood_pileup(&self.case, af_case, None) )
         // cache cannot be used
         } else {
             self.case_sample_model.likelihood_pileup(&self.case, af_case, af_control)
@@ -550,7 +550,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
                     // get likelihood if already cached
             *self.control_likelihood_cache.entry(af_control)
                     // compute and insert otherwise
-                    .or_insert( self.control_sample_model.likelihood_pileup(&self.control, af_control, None) )
+                    .or_insert_with( || self.control_sample_model.likelihood_pileup(&self.control, af_control, None) )
         // cache cannot be used
         } else {
             self.control_sample_model.likelihood_pileup(&self.control, af_control, af_case)


### PR DESCRIPTION
Just as a quick explanation for the verbose new code: I first tried just substituting `or_insert()` with `or_insert_with()`, but the `Rust` ownership model doesn't allow that. `self` needs to be borrowed mutably in that context to allow the insertion to take place, and the call to `self.case_sample_model.likelihood_pileup()` is another (immutable) borrow while the other borrow is still active. Thus the funny scoping of `l` and all...

Also, this code leads to an ~80% runtime reduction in ProSolo:
https://github.com/ProSolo/prosolo/issues/2#issuecomment-407439622