### PR TITLE
Flamegraph annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ approx = "0.1"
 rusty-machine="0.4"
 ordered-float = "0.5"
 ndarray = "0.6"
-# flame = { version = "0.2.2", optional = true }
-flame = "0.2.1-pre2"
+flame = { version = "0.2.1-pre2", optional = true }
 flamer = { version = "^0.2.3", optional = true }
 quick-error = "1.2"
 vec_map = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ approx = "0.1"
 rusty-machine="0.4"
 ordered-float = "0.5"
 ndarray = "0.6"
-flame = { version = "^0.1.2", optional = true }
-flamer = { version = "^0.1.2", optional = true }
+# flame = { version = "0.2.2", optional = true }
+flame = { git = "https://github.com/TyOverby/flame.git", branch = "master", optional = true }
+flamer = { version = "^0.2.3", optional = true }
 quick-error = "1.2"
 vec_map = "0.8"
 regex = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ hyper = "0.10"
 [features]
 default = []
 flame_it = ["flame", "flamer"]
+flame_it_details = ["flame", "flamer", "bio/flame_it_details", "rust-htslib/flame_it_details"]
 gslv2 = ["GSL/v2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rusty-machine="0.4"
 ordered-float = "0.5"
 ndarray = "0.6"
 # flame = { version = "0.2.2", optional = true }
-flame = { git = "https://github.com/TyOverby/flame.git", branch = "master", optional = true }
+flame = "0.2.1-pre2"
 flamer = { version = "^0.2.3", optional = true }
 quick-error = "1.2"
 vec_map = "0.8"

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -43,8 +43,7 @@ impl<A: AlleleFreqs, B: AlleleFreqs> Event for PairEvent<A, B> {
     }
 }
 
-
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 fn pileups<'a, A, B, P>(
     inbcf: &bcf::Reader,
     record: &mut bcf::Record,
@@ -104,7 +103,7 @@ where
 ///
 /// `Result` object with eventual error message.
 
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn call<A, B, P, M, R, W, X, F>(
     inbcf: Option<R>,
     outbcf: Option<W>,

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -43,6 +43,8 @@ impl<A: AlleleFreqs, B: AlleleFreqs> Event for PairEvent<A, B> {
     }
 }
 
+
+#[cfg_attr(feature="flame_it", flame)]
 fn pileups<'a, A, B, P>(
     inbcf: &bcf::Reader,
     record: &mut bcf::Record,
@@ -102,6 +104,7 @@ where
 ///
 /// `Result` object with eventual error message.
 
+#[cfg_attr(feature="flame_it", flame)]
 pub fn call<A, B, P, M, R, W, X, F>(
     inbcf: Option<R>,
     outbcf: Option<W>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 // activate flame levels for the whole crate
-#![cfg_attr(feature="flame_it", feature(plugin))]
-#![cfg_attr(feature="flame_it", plugin(flamer))]
-#![cfg_attr(feature="flame_it_details", feature(plugin))]
-#![cfg_attr(feature="flame_it_details", plugin(flamer))]
+#![cfg_attr(any(feature="flame_it", feature="flame_it_details"), feature(plugin))]
+#![cfg_attr(any(feature="flame_it", feature="flame_it_details"), plugin(flamer))]
 
 extern crate bio;
 extern crate rust_htslib;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // activate flame levels for the whole crate
-#![cfg_attr(any(feature="flame_it", feature="flame_it_details"), feature(plugin))]
-#![cfg_attr(any(feature="flame_it", feature="flame_it_details"), plugin(flamer))]
+#![cfg_attr(any(feature = "flame_it", feature = "flame_it_details"), feature(plugin))]
+#![cfg_attr(any(feature = "flame_it", feature = "flame_it_details"), plugin(flamer))]
 
 extern crate bio;
 extern crate rust_htslib;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
-#![cfg_attr(feature = "flame_it", feature(plugin))]
-#![cfg_attr(feature = "flame_it", plugin(flamer))]
-// activate flame for the whole crate
+// activate flame levels for the whole crate
+#![cfg_attr(feature="flame_it", feature(plugin))]
+#![cfg_attr(feature="flame_it", plugin(flamer))]
+#![cfg_attr(feature="flame_it_details", feature(plugin))]
+#![cfg_attr(feature="flame_it_details", plugin(flamer))]
 
 extern crate bio;
 extern crate rust_htslib;

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -29,12 +29,12 @@ impl LatentVariableModel {
     }
 
     /// Likelihood to observe a read given allele frequencies for case and control.
-    #[cfg_attr(feature="flame_it_details", flame)]
+    #[cfg_attr(feature = "flame_it_details", flame)]
     fn likelihood_observation(
         &self,
         observation: &Observation,
         allele_freq_case: AlleleFreq,
-        allele_freq_control: Option<AlleleFreq>
+        allele_freq_control: Option<AlleleFreq>,
     ) -> LogProb {
         let prob_mismapped = LogProb::ln_one();
 

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -29,11 +29,12 @@ impl LatentVariableModel {
     }
 
     /// Likelihood to observe a read given allele frequencies for case and control.
+    #[cfg_attr(feature="flame_it_details", flame)]
     fn likelihood_observation(
         &self,
         observation: &Observation,
         allele_freq_case: AlleleFreq,
-        allele_freq_control: Option<AlleleFreq>,
+        allele_freq_control: Option<AlleleFreq>
     ) -> LogProb {
         let prob_mismapped = LogProb::ln_one();
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -495,6 +495,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         self.marginal_prob.get().unwrap()
     }
 
+    #[cfg_attr(feature="flame_it", flame)]
     pub fn joint_prob(&mut self, af_case: &A, af_control: &B) -> LogProb {
         let p = self.prior_model.joint_prob(af_case, af_control, self);
         p
@@ -508,11 +509,17 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         prob
     }
 
+    #[cfg_attr(feature="flame_it", flame)]
     pub fn map_allele_freqs(&mut self) -> (AlleleFreq, AlleleFreq) {
         self.prior_model.map(self)
     }
 
-    fn case_likelihood(&mut self, af_case: AlleleFreq, af_control: Option<AlleleFreq>) -> LogProb {
+    #[cfg_attr(feature="flame_it", flame)]
+    fn case_likelihood(
+        &mut self,
+        af_case: AlleleFreq,
+        af_control: Option<AlleleFreq>
+    ) -> LogProb {
         // no af_control given, because case and control are independent
         if af_control.is_none() {
             // get likelihood if already cached
@@ -533,6 +540,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         }
     }
 
+    #[cfg_attr(feature="flame_it", flame)]
     fn control_likelihood(
         &mut self,
         af_control: AlleleFreq,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -495,7 +495,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         self.marginal_prob.get().unwrap()
     }
 
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn joint_prob(&mut self, af_case: &A, af_control: &B) -> LogProb {
         let p = self.prior_model.joint_prob(af_case, af_control, self);
         p
@@ -509,17 +509,13 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         prob
     }
 
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn map_allele_freqs(&mut self) -> (AlleleFreq, AlleleFreq) {
         self.prior_model.map(self)
     }
 
-    #[cfg_attr(feature="flame_it", flame)]
-    fn case_likelihood(
-        &mut self,
-        af_case: AlleleFreq,
-        af_control: Option<AlleleFreq>
-    ) -> LogProb {
+    #[cfg_attr(feature = "flame_it", flame)]
+    fn case_likelihood(&mut self, af_case: AlleleFreq, af_control: Option<AlleleFreq>) -> LogProb {
         // no af_control given, because case and control are independent
         if af_control.is_none() {
             // get likelihood if already cached
@@ -540,7 +536,7 @@ impl<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>> PairPileup<
         }
     }
 
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     fn control_likelihood(
         &mut self,
         af_control: AlleleFreq,

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -45,8 +45,15 @@ impl SingleCellBulkModel {
     // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
     // TODO: allow for non-default Lodato model parameters, e.g. learned from the data at hand
     // TODO: allow for non-Lodato models
-    fn prob_rho(&self, af_single_underlying: &f64, n_obs: &usize, k: &usize) -> LogProb {
-        let binomial_coeff = ln_binomial(*n_obs as u64, *k as u64);
+    #[cfg_attr(feature="flame_it", flame)]
+    fn prob_rho(
+        &self,
+        af_single_underlying: &f64,
+        n_obs: &usize,
+        k: &usize
+    ) -> LogProb
+    {
+        let binomial_coeff = ln_binomial(*n_obs as u64,*k as u64);
 
         match *af_single_underlying {
             // model for hom ref sites

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -45,15 +45,9 @@ impl SingleCellBulkModel {
     // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
     // TODO: allow for non-default Lodato model parameters, e.g. learned from the data at hand
     // TODO: allow for non-Lodato models
-    #[cfg_attr(feature="flame_it", flame)]
-    fn prob_rho(
-        &self,
-        af_single_underlying: &f64,
-        n_obs: &usize,
-        k: &usize
-    ) -> LogProb
-    {
-        let binomial_coeff = ln_binomial(*n_obs as u64,*k as u64);
+    #[cfg_attr(feature = "flame_it", flame)]
+    fn prob_rho(&self, af_single_underlying: &f64, n_obs: &usize, k: &usize) -> LogProb {
+        let binomial_coeff = ln_binomial(*n_obs as u64, *k as u64);
 
         match *af_single_underlying {
             // model for hom ref sites

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -206,6 +206,7 @@ impl Sample {
     }
 
     /// Extract observations for the given variant.
+    #[cfg_attr(feature="flame_it", flame)]
     pub fn extract_observations(
         &mut self,
         start: u32,

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -64,6 +64,7 @@ impl RecordBuffer {
     }
 
     /// Fill buffer around the given interval.
+    #[cfg_attr(feature="flame_it_details", flame)]
     pub fn fill(&mut self, chrom: &[u8], start: u32, end: u32) -> Result<(), Box<Error>> {
         if let Some(tid) = self.reader.header().tid(chrom) {
             let window_start = cmp::max(start as i32 - self.window as i32 - 1, 0) as u32;
@@ -348,6 +349,7 @@ impl Sample {
     }
 
     /// extract within-read evidence for reads covering an indel or SNV of interest
+    #[cfg_attr(feature="flame_it_details", flame)]
     fn read_observation(
         &self,
         record: &bam::Record,
@@ -403,6 +405,7 @@ impl Sample {
     /// * Since there is only one observation per fragment, there is no double counting when
     ///   estimating allele frequencies. Before, we had one observation for an overlapping read
     ///   and potentially another observation for the corresponding fragment.
+    #[cfg_attr(feature="flame_it_details", flame)]
     fn fragment_observation(
         &self,
         left_record: &bam::Record,

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -64,7 +64,7 @@ impl RecordBuffer {
     }
 
     /// Fill buffer around the given interval.
-    #[cfg_attr(feature="flame_it_details", flame)]
+    #[cfg_attr(feature = "flame_it_details", flame)]
     pub fn fill(&mut self, chrom: &[u8], start: u32, end: u32) -> Result<(), Box<Error>> {
         if let Some(tid) = self.reader.header().tid(chrom) {
             let window_start = cmp::max(start as i32 - self.window as i32 - 1, 0) as u32;
@@ -207,7 +207,7 @@ impl Sample {
     }
 
     /// Extract observations for the given variant.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn extract_observations(
         &mut self,
         start: u32,
@@ -349,7 +349,7 @@ impl Sample {
     }
 
     /// extract within-read evidence for reads covering an indel or SNV of interest
-    #[cfg_attr(feature="flame_it_details", flame)]
+    #[cfg_attr(feature = "flame_it_details", flame)]
     fn read_observation(
         &self,
         record: &bam::Record,
@@ -405,7 +405,7 @@ impl Sample {
     /// * Since there is only one observation per fragment, there is no double counting when
     ///   estimating allele frequencies. Before, we had one observation for an overlapping read
     ///   and potentially another observation for the corresponding fragment.
-    #[cfg_attr(feature="flame_it_details", flame)]
+    #[cfg_attr(feature = "flame_it_details", flame)]
     fn fragment_observation(
         &self,
         left_record: &bam::Record,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,6 +173,7 @@ impl ReferenceBuffer {
     }
 
     /// Load given chromosome and return it as a slice. This is O(1) if chromosome was loaded before.
+    #[cfg_attr(feature="flame_it", flame)]
     pub fn seq(&mut self, chrom: &[u8]) -> Result<&[u8], Box<Error>> {
         if let Some(ref last_chrom) = self.chrom {
             if last_chrom == &chrom {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,7 +173,7 @@ impl ReferenceBuffer {
     }
 
     /// Load given chromosome and return it as a slice. This is O(1) if chromosome was loaded before.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn seq(&mut self, chrom: &[u8]) -> Result<&[u8], Box<Error>> {
         if let Some(ref last_chrom) = self.chrom {
             if last_chrom == &chrom {
@@ -388,7 +388,7 @@ impl Overlap {
         Ok(overlap)
     }
 
-    #[cfg_attr(feature="flame_it_details", flame)]
+    #[cfg_attr(feature = "flame_it_details", flame)]
     pub fn is_enclosing(&self) -> bool {
         if let &Overlap::Enclosing(_) = self {
             true

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -388,6 +388,7 @@ impl Overlap {
         Ok(overlap)
     }
 
+    #[cfg_attr(feature="flame_it_details", flame)]
     pub fn is_enclosing(&self) -> bool {
         if let &Overlap::Enclosing(_) = self {
             true


### PR DESCRIPTION
This provides flamegraphing utilities for libprosic on two possible levels, that can be requested as `--features` during compilation of the library (or of a binary that uses `libprosic`):

* `flame_it`: some higher level functions are annotated with the respective `#[cfg_attr(feature = "flame_it", flame)]`feature annotation (enabled by the [flamer crate](https://github.com/llogiq/flamer)) , meaning if `--features flame_it` is requested at compile time, every call of the function will be recorded with start and end (enabled by the [flame crate](https://github.com/TyOverby/flame))
* `flame_it_details` annotates some functions deeper down and is an annotation that could also be used in library dependencies of `libprosic`, e.g. through the respective pull requests in [`rust-bio`](https://github.com/rust-bio/rust-bio/pull/187) and [`rust-htslib`](https://github.com/rust-bio/rust-htslib/pull/105)

For an example how to implement this into binary using libprosic, have a look at [a respecitve issue](https://github.com/ProSolo/prosolo/issues/2) and the commits leading up to [this one](https://github.com/ProSolo/prosolo/commit/37df2e19e3dcd0d03eacf2e89e76f4da2c3f9480) over at [ProSolo](https://github.com/ProSolo/prosolo).

I expect that this will only pass tests, once the above mentioned PRs at `rust-bio` and `rust-htslib` are merged. Also, this points to the latest master branch commits on those projects, which should be changed to some fixed released version before the next release...