### PR TITLE
prob_rho caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1"
 serde_derive = "1"
 csv = "1.0.0-beta.5"
 lazy_static = "0.2"
+cached = "0.7.0"
 statrs = "0.9"
 
 [dev-dependencies]

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -24,8 +24,7 @@ fn phred_scale<'a, I: IntoIterator<Item = &'a Option<LogProb>>>(probs: I) -> Vec
         .map(|&p| match p {
             Some(p) => PHREDProb::from(p).abs() as f32,
             None => f32::missing(),
-        })
-        .collect_vec()
+        }).collect_vec()
 }
 
 pub struct PairEvent<A: AlleleFreqs, B: AlleleFreqs> {
@@ -174,7 +173,8 @@ where
                 "prob_ref",
                 "prob_sample_alt",
                 "evidence",
-            ].iter(),
+            ]
+                .iter(),
         )?;
         Some(writer)
     } else {

--- a/src/estimation/effective_mutation_rate.rs
+++ b/src/estimation/effective_mutation_rate.rs
@@ -36,8 +36,7 @@ pub fn estimate<F: IntoIterator<Item = AlleleFreq>>(allele_frequencies: F) -> Es
         .scan(0.0, |s, c| {
             *s += *c as f64;
             Some(*s)
-        })
-        .collect_vec();
+        }).collect_vec();
 
     let observations = reciprocal_freqs
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ extern crate regex;
 extern crate statrs;
 extern crate vec_map;
 
+#[macro_use]
+extern crate cached;
+
 #[cfg(feature = "flame_it")]
 extern crate flame;
 

--- a/src/model/evidence/mod.rs
+++ b/src/model/evidence/mod.rs
@@ -76,8 +76,7 @@ pub fn max_indel(cigar: &CigarStringView) -> u32 {
             &Cigar::Ins(l) => l,
             &Cigar::Del(l) => l,
             _ => 0,
-        })
-        .max()
+        }).max()
         .unwrap_or(0)
 }
 

--- a/src/model/priors/flat.rs
+++ b/src/model/priors/flat.rs
@@ -45,8 +45,7 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for FlatNormalNormalMod
                     let prob = p_first + p_second;
 
                     prob
-                })
-                .collect_vec(),
+                }).collect_vec(),
         );
 
         prob
@@ -74,8 +73,7 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for FlatNormalNormalMod
                 .minmax_by_key(|&af| {
                     let p = likelihood(*af);
                     NotNaN::new(*p).expect("probability is NaN")
-                })
-                .into_option()
+                }).into_option()
                 .expect("prior has empty allele frequency spectrum");
             *map
         }
@@ -156,8 +154,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                     let prob = p_tumor + p_normal;
 
                     prob
-                })
-                .collect_vec(),
+                }).collect_vec(),
         );
 
         prob
@@ -200,8 +197,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                 let p = pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
                 NotNaN::new(*p).expect("posterior probability is NaN")
-            })
-            .into_option()
+            }).into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (AlleleFreq(map_tumor), *map_normal)

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -330,7 +330,6 @@ mod tests {
 
     #[test]
     fn test_prob_rho() {
-        let model = SingleCellBulkModel::new(2, 5, 100);
         // all expected results calculated with implementation in R version 3.3.3, using
         // dbetabinom.ab() from the R package VGAM_1.0-2
 
@@ -553,19 +552,19 @@ mod tests {
         // test all models
         for k in 0..5 + 1 {
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.0), 5, (k as usize)).exp(),
+                prob_rho(AlleleFreq(0.0), 5, k as usize ).exp(),
                 results_5_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.5), 5, (k as usize)).exp(),
+                prob_rho(AlleleFreq(0.5), 5, k as usize ).exp(),
                 results_5_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(1.0), 5, (k as usize)).exp(),
+                prob_rho(AlleleFreq(1.0), 5, k as usize ).exp(),
                 results_5_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
@@ -573,19 +572,19 @@ mod tests {
         }
         for k in 0..60 + 1 {
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.0), 60, (k as usize)).exp(),
+                prob_rho(AlleleFreq(0.0), 60, k as usize ).exp(),
                 results_60_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.5), 60, (k as usize)).exp(),
+                prob_rho(AlleleFreq(0.5), 60, k as usize ).exp(),
                 results_60_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(1.0), 60, (k as usize)).exp(),
+                prob_rho(AlleleFreq(1.0), 60, k as usize ).exp(),
                 results_60_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -4,6 +4,8 @@ use ordered_float::NotNaN;
 use statrs::function::beta::ln_beta;
 use statrs::function::factorial::ln_binomial;
 
+use cached::UnboundCache;
+
 use model::{AlleleFreq, ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairPileup, Variant};
 
 use priors::PairModel;
@@ -19,6 +21,79 @@ pub struct SingleCellBulkModel {
     allele_freqs_bulk: ContinuousAlleleFreqs,
     n_bulk_min: usize,
     n_bulk_max: usize,
+}
+
+cached! {
+    AMPLIF_CACHE: UnboundCache<(AlleleFreq, usize, usize), LogProb> = UnboundCache::new();
+    // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
+    // TODO: allow for non-default Lodato model parameters, e.g. learned from the data at hand
+    // TODO: allow for non-Lodato models
+    fn prob_rho(af_single_underlying: AlleleFreq, n_obs: usize, k: usize) -> LogProb = {
+
+        // not worth caching, takes only 0.01% of runtime
+        let binomial_coeff = ln_binomial(n_obs as u64, k as u64);
+
+        match af_single_underlying {
+            // model for hom ref sites
+            f if f == AlleleFreq(0.0) => {
+                let alpha = |cov| {
+                    -0.000027183 * cov as f64 + 0.068567471
+                };
+                let beta = |cov| {
+                    0.007454388 * cov as f64 + 2.367486659
+                };
+                let a = alpha(n_obs);
+                let b = beta(n_obs);
+
+                LogProb(
+                    binomial_coeff +
+                        ln_beta((k as f64) + a,  (n_obs) as f64 - (k as f64) + b) - ln_beta(a,b)
+                )
+            },
+            // model for heterozygous sites
+            f if f == AlleleFreq(0.5) => {
+                let weight = |cov| {
+                    0.000548761 * cov as f64 + 0.540396786
+                };
+                let alpha_1 = |cov| {
+                    0.057378844 * cov as f64 + 0.669733191
+                };
+                let alpha_2 = |cov| {
+                    0.003233912 * cov as f64 + 0.399261625
+                };
+
+                let a1 = alpha_1(n_obs);
+                let a2 = alpha_2(n_obs);
+                let w = weight(n_obs);
+
+                // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
+                LogProb(
+                    w.ln() + binomial_coeff +
+                        ln_beta((k as f64) + a1,  (n_obs) as f64 - (k as f64) + a1) - ln_beta(a1,a1)
+                    ).ln_add_exp(
+                        LogProb(
+                            ((-w).ln_1p()) + binomial_coeff +
+                            ln_beta((k as f64) + a2, (n_obs) as f64 - (k as f64) + a2) - ln_beta(a2,a2) )
+                )
+            },
+            // model for hom alt sites (hom ref density mirrored)
+            f if f == AlleleFreq(1.0) => {
+                let alpha = |cov| {
+                    0.007454388 * cov as f64 + 2.367486659
+                };
+                let beta = |cov| {
+                    -0.000027183 * cov as f64 + 0.068567471
+                };
+                let a = alpha(n_obs);
+                let b = beta(n_obs);
+                LogProb(
+                    binomial_coeff +
+                    ln_beta((k as f64) + a,  (n_obs) as f64 - (k as f64) + b) - ln_beta(a,b)
+                )
+            },
+            _ => panic!("SingleCellBulkModel is currently only implemented for the diploid case with allele frequencies 0.0, 0.5 and 1.0.")
+        }
+    }
 }
 
 impl SingleCellBulkModel {
@@ -39,75 +114,6 @@ impl SingleCellBulkModel {
             allele_freqs_bulk: ContinuousAlleleFreqs::inclusive(0.0..1.0),
             n_bulk_min: n_bulk_min, // TODO: implement initialization via command line arguments in ProSolo, i.e. via n_bulk_per_event_min and iteration over events defined in ProSolo
             n_bulk_max: n_bulk_max, // TODO: implement initialization via command line arguments in ProSolo
-        }
-    }
-
-    // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
-    // TODO: allow for non-default Lodato model parameters, e.g. learned from the data at hand
-    // TODO: allow for non-Lodato models
-    fn prob_rho(&self, af_single_underlying: &f64, n_obs: &usize, k: &usize) -> LogProb {
-        let binomial_coeff = ln_binomial(*n_obs as u64, *k as u64);
-
-        match *af_single_underlying {
-            // model for hom ref sites
-            f if f == 0.0 => {
-                let alpha = |cov| {
-                    -0.000027183 * cov as f64 + 0.068567471
-                };
-                let beta = |cov| {
-                    0.007454388 * cov as f64 + 2.367486659
-                };
-                let a = alpha(*n_obs);
-                let b = beta(*n_obs);
-
-                LogProb(
-                    binomial_coeff +
-                        ln_beta((*k as f64) + a,  (*n_obs) as f64 - (*k as f64) + b) - ln_beta(a,b)
-                )
-            },
-            // model for heterozygous sites
-            f if f == 0.5 => {
-                let weight = |cov| {
-                    0.000548761 * cov as f64 + 0.540396786
-                };
-                let alpha_1 = |cov| {
-                    0.057378844 * cov as f64 + 0.669733191
-                };
-                let alpha_2 = |cov| {
-                    0.003233912 * cov as f64 + 0.399261625
-                };
-
-                let a1 = alpha_1(*n_obs);
-                let a2 = alpha_2(*n_obs);
-                let w = weight(*n_obs);
-
-                // Lodato et al. 2015, Science, Supplementary Information, pages 8f and Fig. S5 (A, C, E)
-                LogProb(
-                    w.ln() + binomial_coeff +
-                        ln_beta((*k as f64) + a1,  (*n_obs) as f64 - (*k as f64) + a1) - ln_beta(a1,a1)
-                ).ln_add_exp(
-                    LogProb(
-                        ((-w).ln_1p()) + binomial_coeff +
-                            ln_beta((*k as f64) + a2, (*n_obs) as f64 - (*k as f64) + a2) - ln_beta(a2,a2) )
-                )
-            },
-            // model for hom alt sites (hom ref density mirrored)
-            f if f == 1.0 => {
-                let alpha = |cov| {
-                    0.007454388 * cov as f64 + 2.367486659
-                };
-                let beta = |cov| {
-                    -0.000027183 * cov as f64 + 0.068567471
-                };
-                let a = alpha(*n_obs);
-                let b = beta(*n_obs);
-
-                LogProb(
-                    binomial_coeff +
-                        ln_beta((*k as f64) + a,  (*n_obs) as f64 - (*k as f64) + b) - ln_beta(a,b)
-                )
-            },
-            _ => panic!("SingleCellBulkModel is currently only implemented for the diploid case with allele frequencies 0.0, 0.5 and 1.0.")
         }
     }
 
@@ -238,7 +244,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                                         AlleleFreq(k_s as f64 / n_single as f64);
                                     self.prior_single(af_single, &pileup.variant)
                                         + pileup.case_likelihood(af_single_distorted, None)
-                                        + self.prob_rho(&af_single, &n_single, &k_s)
+                                        + prob_rho(af_single, n_single, k_s)
                                 }
                             })
                             .collect_vec(),
@@ -284,7 +290,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                                 let af_single_distorted = AlleleFreq(k_s as f64 / n_single as f64);
                                 self.prior_single(af_single, &pileup.variant)
                                     + pileup.case_likelihood(af_single_distorted, None)
-                                    + self.prob_rho(&af_single, &n_single, &k_s)
+                                    + prob_rho(af_single, n_single, k_s)
                             }
                         })
                         .collect_vec(),
@@ -549,19 +555,19 @@ mod tests {
         // test all models
         for k in 0..5 + 1 {
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(0.0), &5, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(0.0), 5, (k as usize)).exp(),
                 results_5_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(0.5), &5, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(0.5), 5, (k as usize)).exp(),
                 results_5_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(1.0), &5, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(1.0), 5, (k as usize)).exp(),
                 results_5_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
@@ -569,19 +575,19 @@ mod tests {
         }
         for k in 0..60 + 1 {
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(0.0), &60, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(0.0), 60, (k as usize)).exp(),
                 results_60_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(0.5), &60, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(0.5), 60, (k as usize)).exp(),
                 results_60_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                model.prob_rho(&AlleleFreq(1.0), &60, &(k as usize)).exp(),
+                prob_rho(AlleleFreq(1.0), 60, (k as usize)).exp(),
                 results_60_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -552,19 +552,19 @@ mod tests {
         // test all models
         for k in 0..5 + 1 {
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.0), 5, k as usize ).exp(),
+                prob_rho(AlleleFreq(0.0), 5, k as usize).exp(),
                 results_5_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.5), 5, k as usize ).exp(),
+                prob_rho(AlleleFreq(0.5), 5, k as usize).exp(),
                 results_5_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(1.0), 5, k as usize ).exp(),
+                prob_rho(AlleleFreq(1.0), 5, k as usize).exp(),
                 results_5_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
@@ -572,19 +572,19 @@ mod tests {
         }
         for k in 0..60 + 1 {
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.0), 60, k as usize ).exp(),
+                prob_rho(AlleleFreq(0.0), 60, k as usize).exp(),
                 results_60_hom_ref[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(0.5), 60, k as usize ).exp(),
+                prob_rho(AlleleFreq(0.5), 60, k as usize).exp(),
                 results_60_het[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001
             );
             assert_relative_eq!(
-                prob_rho(AlleleFreq(1.0), 60, k as usize ).exp(),
+                prob_rho(AlleleFreq(1.0), 60, k as usize).exp(),
                 results_60_hom_alt[k] as f64,
                 max_relative = 1.0,
                 epsilon = 0.000000000001

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -198,8 +198,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                             + pileup.control_likelihood(af_bulk, None)
                     }
                     p
-                })
-                .collect_vec(),
+                }).collect_vec(),
         );
 
         /*
@@ -308,8 +307,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                 let p_bulk = self.prior_bulk(*af_bulk, &pileup.variant)
                     + pileup.control_likelihood(*af_bulk, None);
                 NotNaN::new(*p_bulk).expect("posterior probability is NaN")
-            })
-            .into_option()
+            }).into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (*map_single, map_bulk)

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -178,8 +178,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
                     let prob = p_tumor + p_normal;
 
                     prob
-                })
-                .collect_vec(),
+                }).collect_vec(),
         );
 
         prob
@@ -221,8 +220,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
                     + pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
                 NotNaN::new(*p).expect("posterior probability is NaN")
-            })
-            .into_option()
+            }).into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (AlleleFreq(map_tumor), *map_normal)

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -475,8 +475,7 @@ impl Sample {
                     .indel_read_evidence
                     .borrow()
                     .prob_mapping(right_record)
-                    .ln_one_minus_exp())
-                .ln_one_minus_exp(),
+                    .ln_one_minus_exp()).ln_one_minus_exp(),
             p_alt_isize + p_alt_left + p_alt_right,
             p_ref_isize + p_ref_left + p_ref_right,
             prob_sample_alt,
@@ -524,15 +523,16 @@ pub fn isize_density_louis(value: f64, mean: f64, sd: f64) -> LogProb {
 }
 
 pub fn isize_mixture_density_louis(value: f64, d: f64, mean: f64, sd: f64, rate: f64) -> LogProb {
-    let p = 0.5 / (rate * (1.0 - 0.5 * erfc((mean + 0.5) / sd * consts::FRAC_1_SQRT_2))
-        + (1.0 - rate) * (1.0 - 0.5 * erfc((mean + d + 0.5) / sd * consts::FRAC_1_SQRT_2)));
+    let p = 0.5
+        / (rate * (1.0 - 0.5 * erfc((mean + 0.5) / sd * consts::FRAC_1_SQRT_2))
+            + (1.0 - rate) * (1.0 - 0.5 * erfc((mean + d + 0.5) / sd * consts::FRAC_1_SQRT_2)));
     LogProb(
-        (p * (rate * (erfc((-value - 0.5 + mean) / sd * consts::FRAC_1_SQRT_2)
-            - erfc((-value + 0.5 + mean) / sd * consts::FRAC_1_SQRT_2))
+        (p * (rate
+            * (erfc((-value - 0.5 + mean) / sd * consts::FRAC_1_SQRT_2)
+                - erfc((-value + 0.5 + mean) / sd * consts::FRAC_1_SQRT_2))
             + (1.0 - rate)
                 * (erfc((-value - 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2)
-                    - erfc((-value + 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2))))
-            .ln(),
+                    - erfc((-value + 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2)))).ln(),
     )
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -257,8 +257,7 @@ fn tags_prob_sum(
             } else {
                 None
             }
-        })
-        .collect_vec())
+        }).collect_vec())
 }
 
 /// Collect distribution of posterior probabilities from a VCF file that has been written by

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -54,8 +54,7 @@ fn download_reference(chrom: &str) -> String {
             .get(&format!(
                 "http://hgdownload.cse.ucsc.edu/goldenpath/hg18/chromosomes/{}.fa.gz",
                 chrom
-            ))
-            .send()
+            )).send()
             .unwrap();
         let mut reference_stream = flate2::read::GzDecoder::new(res).unwrap();
         let mut reference_file = fs::File::create(&reference).unwrap();


### PR DESCRIPTION
This PR introduces the use of the [`cached` crate](https://docs.rs/cached) to cache the computations by the `single-cell-bulk` model function `prob_rho()`. This cache has to be defined outside of the model to allow for its mutability--but I could imagine a wrapper Trait and separate wrapper implementations of that that Trait for different whole genome amplification methods, should we include more at some point. For now, I would keep it as is.