### PR TITLE
ContinuousAlleleFreqs of points should be inclusive or exclusive

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -119,6 +119,9 @@ impl ContinuousAlleleFreqs {
 
     /// create a left-exclusive allele frequency range
     pub fn left_exclusive(range: Range<f64>) -> Self {
+        if range.start == range.end {
+            panic!("ContinuousAlleleFreqs::left_exclusive({}..{}) does not make sense with identical start and end point.", range.start, range.end);
+        }
         ContinuousAlleleFreqs {
             inner: AlleleFreq(range.start)..AlleleFreq(range.end),
             left_exclusive: true,
@@ -128,6 +131,9 @@ impl ContinuousAlleleFreqs {
 
     /// create a right-exclusive allele frequency range
     pub fn right_exclusive(range: Range<f64>) -> Self {
+        if range.start == range.end {
+            panic!("ContinuousAlleleFreqs::right_exclusive({}..{}) does not make sense with identical start and end point.", range.start, range.end);
+        }
         ContinuousAlleleFreqs {
             inner: AlleleFreq(range.start)..AlleleFreq(range.end),
             left_exclusive: false,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -141,7 +141,7 @@ fn call_tumor_normal(test: &str, exclusive_end: bool, chrom: &str) {
         },
         libprosic::call::pairwise::PairEvent {
             name: "absent".to_owned(),
-            af_case: ContinuousAlleleFreqs::left_exclusive(0.0..0.0),
+            af_case: ContinuousAlleleFreqs::exclusive(0.0..0.0),
             af_control: DiscreteAlleleFreqs::absent(),
         },
     ];


### PR DESCRIPTION
at both ends, one-sided exclusivity does not make sense.