### PR TITLE
Minimize ln operations

### DIFF
--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -169,6 +169,7 @@ where
                 "allele",
                 "sample",
                 "prob_mapping",
+                "prob_one_minus_mapping",
                 "prob_alt",
                 "prob_ref",
                 "prob_sample_alt",

--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -169,7 +169,7 @@ where
                 "allele",
                 "sample",
                 "prob_mapping",
-                "prob_one_minus_mapping",
+                "prob_mismapping",
                 "prob_alt",
                 "prob_ref",
                 "prob_sample_alt",

--- a/src/model/evidence/observation.rs
+++ b/src/model/evidence/observation.rs
@@ -14,6 +14,8 @@ use rust_htslib::bam::record::CigarString;
 pub struct Observation {
     /// Posterior probability that the read/read-pair has been mapped correctly (1 - MAPQ).
     pub prob_mapping: LogProb,
+    /// Posterior probability that the read/read-pair has been mapped incorrectly (MAPQ).
+    pub prob_one_minus_mapping: LogProb,
     /// Probability that the read/read-pair comes from the alternative allele.
     pub prob_alt: LogProb,
     /// Probability that the read/read-pair comes from the reference allele.
@@ -27,6 +29,7 @@ pub struct Observation {
 impl Observation {
     pub fn new(
         prob_mapping: LogProb,
+        prob_one_minus_mapping: LogProb,
         prob_alt: LogProb,
         prob_ref: LogProb,
         prob_sample_alt: LogProb,
@@ -34,6 +37,7 @@ impl Observation {
     ) -> Self {
         Observation {
             prob_mapping: prob_mapping,
+            prob_one_minus_mapping: prob_one_minus_mapping,
             prob_alt: prob_alt,
             prob_ref: prob_ref,
             prob_sample_alt: prob_sample_alt,
@@ -69,6 +73,7 @@ impl Serialize for Observation {
     {
         let mut s = serializer.serialize_struct("Observation", 3)?;
         s.serialize_field("prob_mapping", &self.prob_mapping)?;
+        s.serialize_field("prob_one_minus_mapping", &self.prob_one_minus_mapping)?;
         s.serialize_field("prob_alt", &self.prob_alt)?;
         s.serialize_field("prob_ref", &self.prob_ref)?;
         s.serialize_field("prob_sample_alt", &self.prob_sample_alt)?;

--- a/src/model/evidence/observation.rs
+++ b/src/model/evidence/observation.rs
@@ -15,7 +15,7 @@ pub struct Observation {
     /// Posterior probability that the read/read-pair has been mapped correctly (1 - MAPQ).
     pub prob_mapping: LogProb,
     /// Posterior probability that the read/read-pair has been mapped incorrectly (MAPQ).
-    pub prob_one_minus_mapping: LogProb,
+    pub prob_mismapping: LogProb,
     /// Probability that the read/read-pair comes from the alternative allele.
     pub prob_alt: LogProb,
     /// Probability that the read/read-pair comes from the reference allele.
@@ -29,7 +29,7 @@ pub struct Observation {
 impl Observation {
     pub fn new(
         prob_mapping: LogProb,
-        prob_one_minus_mapping: LogProb,
+        prob_mismapping: LogProb,
         prob_alt: LogProb,
         prob_ref: LogProb,
         prob_sample_alt: LogProb,
@@ -37,7 +37,7 @@ impl Observation {
     ) -> Self {
         Observation {
             prob_mapping: prob_mapping,
-            prob_one_minus_mapping: prob_one_minus_mapping,
+            prob_mismapping: prob_mismapping,
             prob_alt: prob_alt,
             prob_ref: prob_ref,
             prob_sample_alt: prob_sample_alt,
@@ -73,7 +73,7 @@ impl Serialize for Observation {
     {
         let mut s = serializer.serialize_struct("Observation", 3)?;
         s.serialize_field("prob_mapping", &self.prob_mapping)?;
-        s.serialize_field("prob_one_minus_mapping", &self.prob_one_minus_mapping)?;
+        s.serialize_field("prob_mismapping", &self.prob_mismapping)?;
         s.serialize_field("prob_alt", &self.prob_alt)?;
         s.serialize_field("prob_ref", &self.prob_ref)?;
         s.serialize_field("prob_sample_alt", &self.prob_sample_alt)?;

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -58,7 +58,7 @@ impl LatentVariableModel {
 
         // Step 4: total probability
         let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
-         .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
+         .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
         //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
         assert!(!total.is_nan());
         total
@@ -81,7 +81,7 @@ impl LatentVariableModel {
 
         // Step 3: total probability
         let total = (observation.prob_mapping + prob_case)
-            .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
+            .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
         assert!(!total.is_nan());
         total
     }

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -131,7 +131,6 @@ mod tests {
 
     #[test]
     fn test_likelihood_observation_absent_single() {
-        let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_zero(), LogProb::ln_one());
 
         let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(0.0));
@@ -180,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn test_likelihood_observation() {
+    fn test_likelihood_observation_case_control() {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_one(), LogProb::ln_zero());
 
@@ -204,6 +203,29 @@ mod tests {
 
         let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.0), AlleleFreq(1.0));
         assert_relative_eq!(*lh, 0.5f64.ln());
+    }
+
+    #[test]
+    fn test_likelihood_observation_single_sample() {
+        let observation = observation(
+                                // prob_mapping
+                                LogProb::ln_one(),
+                                // prob_alt
+                                LogProb::ln_one(),
+                                // prob_ref
+                                LogProb::ln_zero());
+
+        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(1.0));
+        assert_relative_eq!(*lh, *LogProb::ln_one());
+
+        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(0.0));
+        assert_relative_eq!(*lh, *LogProb::ln_zero());
+
+        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(0.5));
+        assert_relative_eq!(*lh, 0.5f64.ln());
+
+        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(0.1));
+        assert_relative_eq!(*lh, 0.1f64.ln());
     }
 
     #[test]

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -37,20 +37,17 @@ impl LatentVariableModel {
     ) -> LogProb {
         let prob_mismapped = LogProb::ln_one();
 
-           // Step 1: probability to sample observation: AF * placement induced probability
-        let prob_sample_alt_case =
-            allele_freq_case + observation.prob_sample_alt;
-        let prob_sample_alt_control =
-            allele_freq_control + observation.prob_sample_alt;
+        // Step 1: probability to sample observation: AF * placement induced probability
+        let prob_sample_alt_case = allele_freq_case + observation.prob_sample_alt;
+        let prob_sample_alt_control = allele_freq_control + observation.prob_sample_alt;
 
         // Step 2: read comes from control sample and is correctly mapped
         let prob_control = self.impurity.unwrap()
-            + (prob_sample_alt_control + observation.prob_alt).ln_add_exp(
-                prob_sample_alt_control.ln_one_minus_exp() + observation.prob_ref,
-            );
+            + (prob_sample_alt_control + observation.prob_alt)
+                .ln_add_exp(prob_sample_alt_control.ln_one_minus_exp() + observation.prob_ref);
         assert!(!prob_control.is_nan());
 
-           // Step 3: read comes from case sample and is correctly mapped
+        // Step 3: read comes from case sample and is correctly mapped
         let prob_case = self.purity.unwrap()
             + (prob_sample_alt_case + observation.prob_alt)
                 .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);
@@ -58,7 +55,7 @@ impl LatentVariableModel {
 
         // Step 4: total probability
         let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
-         .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
+            .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
         //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
         assert!(!total.is_nan());
         total
@@ -100,10 +97,11 @@ impl LatentVariableModel {
                 let ln_af_control = LogProb(allele_freq_control.ln());
                 // calculate product of per-read likelihoods in log space
                 likelihood = pileup.iter().fold(LogProb::ln_one(), |prob, obs| {
-                    let lh = self.likelihood_observation_case_control(obs, ln_af_case, ln_af_control);
+                    let lh =
+                        self.likelihood_observation_case_control(obs, ln_af_case, ln_af_control);
                     prob + lh
                 });
-            },
+            }
             None => {
                 // no AF for control sample given
                 if let Some(purity) = self.purity {
@@ -118,7 +116,7 @@ impl LatentVariableModel {
                     let lh = Self::likelihood_observation_single_sample(obs, ln_af_case);
                     prob + lh
                 });
-            },
+            }
         }
         assert!(!likelihood.is_nan());
         likelihood
@@ -136,7 +134,10 @@ mod tests {
     fn test_likelihood_observation_absent_single() {
         let observation = observation(LogProb::ln_one(), LogProb::ln_zero(), LogProb::ln_one());
 
-        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, LogProb(AlleleFreq(0.0).ln()));
+        let lh = LatentVariableModel::likelihood_observation_single_sample(
+            &observation,
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_one());
     }
 
@@ -145,7 +146,11 @@ mod tests {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_zero(), LogProb::ln_one());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.0).ln()), LogProb(AlleleFreq(0.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.0).ln()),
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_one());
     }
 
@@ -186,48 +191,85 @@ mod tests {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_one(), LogProb::ln_zero());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(1.0).ln()), LogProb(AlleleFreq(0.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(1.0).ln()),
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_one());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.0).ln()), LogProb(AlleleFreq(0.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.0).ln()),
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_zero());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.5).ln()), LogProb(AlleleFreq(0.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.5).ln()),
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.5).ln()), LogProb(AlleleFreq(0.5).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.5).ln()),
+            LogProb(AlleleFreq(0.5).ln()),
+        );
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.1).ln()), LogProb(AlleleFreq(0.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.1).ln()),
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, 0.1f64.ln());
 
         // test with 50% purity
         let model = LatentVariableModel::new(0.5);
 
-        let lh = model.likelihood_observation_case_control(&observation, LogProb(AlleleFreq(0.0).ln()), LogProb(AlleleFreq(1.0).ln()));
+        let lh = model.likelihood_observation_case_control(
+            &observation,
+            LogProb(AlleleFreq(0.0).ln()),
+            LogProb(AlleleFreq(1.0).ln()),
+        );
         assert_relative_eq!(*lh, 0.5f64.ln());
     }
 
     #[test]
     fn test_likelihood_observation_single_sample() {
         let observation = observation(
-                                // prob_mapping
-                                LogProb::ln_one(),
-                                // prob_alt
-                                LogProb::ln_one(),
-                                // prob_ref
-                                LogProb::ln_zero());
+            // prob_mapping
+            LogProb::ln_one(),
+            // prob_alt
+            LogProb::ln_one(),
+            // prob_ref
+            LogProb::ln_zero(),
+        );
 
-        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, LogProb(AlleleFreq(1.0).ln()));
+        let lh = LatentVariableModel::likelihood_observation_single_sample(
+            &observation,
+            LogProb(AlleleFreq(1.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_one());
 
-        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, LogProb(AlleleFreq(0.0).ln()));
+        let lh = LatentVariableModel::likelihood_observation_single_sample(
+            &observation,
+            LogProb(AlleleFreq(0.0).ln()),
+        );
         assert_relative_eq!(*lh, *LogProb::ln_zero());
 
-        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, LogProb(AlleleFreq(0.5).ln()));
+        let lh = LatentVariableModel::likelihood_observation_single_sample(
+            &observation,
+            LogProb(AlleleFreq(0.5).ln()),
+        );
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, LogProb(AlleleFreq(0.1).ln()));
+        let lh = LatentVariableModel::likelihood_observation_single_sample(
+            &observation,
+            LogProb(AlleleFreq(0.1).ln()),
+        );
         assert_relative_eq!(*lh, 0.1f64.ln());
     }
 

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -35,8 +35,6 @@ impl LatentVariableModel {
         allele_freq_case: LogProb,
         allele_freq_control: LogProb,
     ) -> LogProb {
-        let prob_mismapped = LogProb::ln_one();
-
         // Step 1: probability to sample observation: AF * placement induced probability
         let prob_sample_alt_case = allele_freq_case + observation.prob_sample_alt;
         let prob_sample_alt_control = allele_freq_control + observation.prob_sample_alt;
@@ -55,7 +53,7 @@ impl LatentVariableModel {
 
         // Step 4: total probability
         let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
-            .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
+            .ln_add_exp(observation.prob_mismapping);
         //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
         assert!(!total.is_nan());
         total
@@ -66,8 +64,6 @@ impl LatentVariableModel {
         observation: &Observation,
         allele_freq_case: LogProb,
     ) -> LogProb {
-        let prob_mismapped = LogProb::ln_one();
-
         // Step 1: calculate probability to sample from alt allele
         let prob_sample_alt = allele_freq_case + observation.prob_sample_alt;
 
@@ -77,8 +73,7 @@ impl LatentVariableModel {
         assert!(!prob_case.is_nan());
 
         // Step 3: total probability
-        let total = (observation.prob_mapping + prob_case)
-            .ln_add_exp(observation.prob_one_minus_mapping + prob_mismapped);
+        let total = (observation.prob_mapping + prob_case).ln_add_exp(observation.prob_mismapping);
         assert!(!total.is_nan());
         total
     }

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -29,66 +29,61 @@ impl LatentVariableModel {
     }
 
     /// Likelihood to observe a read given allele frequencies for case and control.
-    fn likelihood_observation(
+    fn likelihood_observation_case_control(
         &self,
         observation: &Observation,
         allele_freq_case: AlleleFreq,
-        allele_freq_control: Option<AlleleFreq>,
+        allele_freq_control: AlleleFreq,
     ) -> LogProb {
         let prob_mismapped = LogProb::ln_one();
 
-        match (allele_freq_control, self.purity) {
-            (Some(allele_freq_control), Some(purity)) => {
-                // Step 1: probability to sample observation: AF * placement induced probability
-                let prob_sample_alt_case =
-                    LogProb(allele_freq_case.ln()) + observation.prob_sample_alt;
-                let prob_sample_alt_control =
-                    LogProb(allele_freq_control.ln()) + observation.prob_sample_alt;
+           // Step 1: probability to sample observation: AF * placement induced probability
+        let prob_sample_alt_case =
+            LogProb(allele_freq_case.ln()) + observation.prob_sample_alt;
+        let prob_sample_alt_control =
+            LogProb(allele_freq_control.ln()) + observation.prob_sample_alt;
 
-                // Step 2: read comes from control sample and is correctly mapped
-                let prob_control = self.impurity.unwrap()
-                    + (prob_sample_alt_control + observation.prob_alt).ln_add_exp(
-                        prob_sample_alt_control.ln_one_minus_exp() + observation.prob_ref,
-                    );
-                assert!(!prob_control.is_nan());
+        // Step 2: read comes from control sample and is correctly mapped
+        let prob_control = self.impurity.unwrap()
+            + (prob_sample_alt_control + observation.prob_alt).ln_add_exp(
+                prob_sample_alt_control.ln_one_minus_exp() + observation.prob_ref,
+            );
+        assert!(!prob_control.is_nan());
 
-                // Step 3: read comes from case sample and is correctly mapped
-                let prob_case = purity
-                    + (prob_sample_alt_case + observation.prob_alt)
-                        .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);
-                assert!(!prob_case.is_nan());
+           // Step 3: read comes from case sample and is correctly mapped
+        let prob_case = self.purity.unwrap()
+            + (prob_sample_alt_case + observation.prob_alt)
+                .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);
+        assert!(!prob_case.is_nan());
 
-                // Step 4: total probability
-                let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
-                    .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
-                //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
-                assert!(!total.is_nan());
-                total
-            }
-            (None, purity) => {
-                // no AF for control sample given
-                if let Some(purity) = purity {
-                    assert!(
-                        purity == LogProb::ln_one(),
-                        "no control allele frequency given but purity is not 1.0"
-                    );
-                }
-                // Step 1: calculate probability to sample from alt allele
-                let prob_sample_alt = LogProb(allele_freq_case.ln()) + observation.prob_sample_alt;
+        // Step 4: total probability
+        let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
+         .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
+        //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
+        assert!(!total.is_nan());
+        total
+    }
 
-                // Step 2: read comes from case sample and is correctly mapped
-                let prob_case = (prob_sample_alt + observation.prob_alt)
-                    .ln_add_exp(prob_sample_alt.ln_one_minus_exp() + observation.prob_ref);
-                assert!(!prob_case.is_nan());
+    /// Likelihood to observe a read given allele frequency for a single sample.
+    fn likelihood_observation_single_sample(
+        observation: &Observation,
+        allele_freq_case: AlleleFreq,
+    ) -> LogProb {
+        let prob_mismapped = LogProb::ln_one();
 
-                // Step 3: total probability
-                let total = (observation.prob_mapping + prob_case)
-                    .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
-                assert!(!total.is_nan());
-                total
-            }
-            (Some(_), None) => panic!("control allele frequency given but purity not defined"),
-        }
+        // Step 1: calculate probability to sample from alt allele
+        let prob_sample_alt = LogProb(allele_freq_case.ln()) + observation.prob_sample_alt;
+
+        // Step 2: read comes from case sample and is correctly mapped
+        let prob_case = (prob_sample_alt + observation.prob_alt)
+            .ln_add_exp(prob_sample_alt.ln_one_minus_exp() + observation.prob_ref);
+        assert!(!prob_case.is_nan());
+
+        // Step 3: total probability
+        let total = (observation.prob_mapping + prob_case)
+            .ln_add_exp(observation.prob_mapping.ln_one_minus_exp() + prob_mismapped);
+        assert!(!total.is_nan());
+        total
     }
 
     /// Likelihood to observe a pileup given allele frequencies for case and control.
@@ -98,11 +93,30 @@ impl LatentVariableModel {
         allele_freq_case: AlleleFreq,
         allele_freq_control: Option<AlleleFreq>,
     ) -> LogProb {
-        // calculate product of per-read likelihoods in log space
-        let likelihood = pileup.iter().fold(LogProb::ln_one(), |prob, obs| {
-            let lh = self.likelihood_observation(obs, allele_freq_case, allele_freq_control);
-            prob + lh
-        });
+        let likelihood;
+        match allele_freq_control {
+            Some(allele_freq_control) => {
+                // calculate product of per-read likelihoods in log space
+                likelihood = pileup.iter().fold(LogProb::ln_one(), |prob, obs| {
+                    let lh = self.likelihood_observation_case_control(obs, allele_freq_case, allele_freq_control);
+                    prob + lh
+                });
+            },
+            None => {
+                // no AF for control sample given
+                if let Some(purity) = self.purity {
+                    assert!(
+                        purity == LogProb::ln_one(),
+                        "no control allele frequency given but purity is not 1.0"
+                    );
+                }
+                // calculate product of per-read likelihoods in log space
+                likelihood = pileup.iter().fold(LogProb::ln_one(), |prob, obs| {
+                    let lh = Self::likelihood_observation_single_sample(obs, allele_freq_case);
+                    prob + lh
+                });
+            },
+        }
         assert!(!likelihood.is_nan());
         likelihood
     }
@@ -120,7 +134,7 @@ mod tests {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_zero(), LogProb::ln_one());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.0), None);
+        let lh = LatentVariableModel::likelihood_observation_single_sample(&observation, AlleleFreq(0.0));
         assert_relative_eq!(*lh, *LogProb::ln_one());
     }
 
@@ -129,7 +143,7 @@ mod tests {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_zero(), LogProb::ln_one());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.0), Some(AlleleFreq(0.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.0), AlleleFreq(0.0));
         assert_relative_eq!(*lh, *LogProb::ln_one());
     }
 
@@ -170,25 +184,25 @@ mod tests {
         let model = LatentVariableModel::new(1.0);
         let observation = observation(LogProb::ln_one(), LogProb::ln_one(), LogProb::ln_zero());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(1.0), Some(AlleleFreq(0.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(1.0), AlleleFreq(0.0));
         assert_relative_eq!(*lh, *LogProb::ln_one());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.0), Some(AlleleFreq(0.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.0), AlleleFreq(0.0));
         assert_relative_eq!(*lh, *LogProb::ln_zero());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.5), Some(AlleleFreq(0.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.5), AlleleFreq(0.0));
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.5), Some(AlleleFreq(0.5)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.5), AlleleFreq(0.5));
         assert_relative_eq!(*lh, 0.5f64.ln());
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.1), Some(AlleleFreq(0.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.1), AlleleFreq(0.0));
         assert_relative_eq!(*lh, 0.1f64.ln());
 
         // test with 50% purity
         let model = LatentVariableModel::new(0.5);
 
-        let lh = model.likelihood_observation(&observation, AlleleFreq(0.0), Some(AlleleFreq(1.0)));
+        let lh = model.likelihood_observation_case_control(&observation, AlleleFreq(0.0), AlleleFreq(1.0));
         assert_relative_eq!(*lh, 0.5f64.ln());
     }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -629,6 +629,7 @@ mod tests {
     pub fn observation(prob_mapping: LogProb, prob_alt: LogProb, prob_ref: LogProb) -> Observation {
         Observation::new(
             prob_mapping,
+            prob_mapping.ln_one_minus_exp(),
             prob_alt,
             prob_ref,
             LogProb::ln_one(),

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -370,7 +370,10 @@ impl Sample {
         };
 
         if let Some((prob_ref, prob_alt)) = probs {
-            let (prob_mapping, prob_mismapping) = self.indel_read_evidence.borrow().prob_mapping_mismapping(record);
+            let (prob_mapping, prob_mismapping) = self
+                .indel_read_evidence
+                .borrow()
+                .prob_mapping_mismapping(record);
 
             let prob_sample_alt = self
                 .indel_read_evidence
@@ -467,13 +470,13 @@ impl Sample {
         assert!(p_ref_right.is_valid());
 
         let (_, prob_mismapping_left) = self
-                                            .indel_read_evidence
-                                            .borrow()
-                                            .prob_mapping_mismapping(left_record);
+            .indel_read_evidence
+            .borrow()
+            .prob_mapping_mismapping(left_record);
         let (_, prob_mismapping_right) = self
-                                            .indel_read_evidence
-                                            .borrow()
-                                            .prob_mapping_mismapping(right_record);
+            .indel_read_evidence
+            .borrow()
+            .prob_mapping_mismapping(right_record);
         let prob_mismapping = prob_mismapping_left + prob_mismapping_right;
         let obs = Observation::new(
             prob_mismapping.ln_one_minus_exp(),


### PR DESCRIPTION
I implemented 4 optimisation ideas that @johanneskoester and I had, but only one of them gave any significant savings:

* creating the new field `prob_one_minus_mapping` in `Observation` that gets computed when a new observation is created -- thus, when a read is used multiple times (e.g. for multiple variants it spans or for the likelihood of different `Event`s) this is only calculated once and then just pulled up every time needed

This seems to shave another 15% off of the previous best prosolo runtime (on PR #46).

**Please double-check the changes, especially for `prob_one_minus_mapping` commit, as that changed different spots around the codebase, including some newer indel code!**

Here are the `time`s and flamegraphs, computed on a 1 Mb slice of `chr4` in an exome dataset, with timing averaged over 4 separate runs each:

## prob_rho caching

### libprosic commit

```
f6c5a4c80615119f782e2e1dbc4fcfc64adc4f15
```

### prosolo commit

```
4ad38e2605f6793be99e4fbf7c3adb63b97e3df8
```

### time

```
real	3m13.317s
user	3m12.624s
sys	0m0.684s
```

```
real	3m15.503s
user	3m14.828s
sys	0m0.620s
```

```
real	3m13.883s
user	3m13.108s
sys	0m0.612s
```

```
real	3m15.715s
user	3m14.936s
sys	0m0.744s
```

```
((3+3+3+3)*60+12,624+14,828+13,108+14,936)/4 = 193,874
```

### flamegraph

Please see the following gist (right-click on the thumbnail there and choose `View image` for interactive SVG):
<https://gist.github.com/dlaehnemann/e9d07bae9141658d4804f841e0f98329>

## impurity calculation upon instantiation

### libprosic commit

```
1c64d3b2eeff51669beaf087a1b4b149bf2a34ce
```

### prosolo commit

```
9bb7fc793dd58642935e461d3ed4c89f8b3b1a18
```

### times

```
real	3m18.351s
user	3m17.216s
sys	0m0.784s
```

```
real	3m23.281s
user	3m22.496s
sys	0m0.748s
```

```
real	3m21.297s
user	3m20.568s
sys	0m0.696s
```

```
real	3m24.442s
user	3m23.708s
sys	0m0.688s
```

```
((3+3+3+3)*60+17,216+22,496+20,568+23,708)/4 = 200,997
```

### flamegraph

<https://gist.github.com/dlaehnemann/8c61be5bb70a1b425058dfbff57f1507>


## match statement moved from likelihood_observation up to likelihood_pileup

### libprosic commit

```
57f349ef81e0008eb0cc663f0af8f2d6a488a54d
```

### prosolo commit

```
9bb7fc793dd58642935e461d3ed4c89f8b3b1a18
```

### times

```
real	3m20.241s
user	3m19.600s
sys	0m0.584s
```

```
real	3m17.376s
user	3m16.600s
sys	0m0.720s
```

```
real	3m29.694s
user	3m29.000s
sys	0m0.656s
```

```
real	3m23.196s
user	3m22.412s
sys	0m0.724s
```

```
((3+3+3+3)*60+19,600+16,600+29,000+22,412)/4 = 201,903
```

Re-compiled after `cargo clean` & power cable connected, to get a feeling if this makes a difference:

```
real	3m13.916s
user	3m13.288s
sys	0m0.688s
```

```
real	3m18.739s
user	3m18.012s
sys	0m0.688s
```

```
real	3m21.528s
user	3m20.812s
sys	0m0.696s
```

```
real	3m18.988s
user	3m18.480s
sys	0m0.544s
```

```
((3+3+3+3)*60+13,288+18,012+20,812+18,480)/4 = 197,648
```

This does not look like a meaningful speed improvement, possibly because the rust compiler already optimised this away?

### flamegraph

<https://gist.github.com/dlaehnemann/bf440ea4ac91f36f49dc38882607e6a3>

## calculate LogProb of allele_freq_case and allele_freq_control per pileup, not per observation

### libprosic commit

```
91396e50cf49ffdd32c85610585521d10b8d5dd3
```

### prosolo commit

```
9bb7fc793dd58642935e461d3ed4c89f8b3b1a18
```

### times

```
real	3m21.013s
user	3m20.172s
sys	0m0.808s
```

```
real	3m19.297s
user	3m18.736s
sys	0m0.544s
```

New day, with power cable connected...
```
real	3m14.285s
user	3m13.268s
sys	0m0.656s
```

```
real	3m12.624s
user	3m11.904s
sys	0m0.692s
```

```
((3+3+3+3)*60+20,172+18,736+13,268+11,904)/4 = 196,02
```

This does not look like a meaningful speedup, possibly because the rust compiler already optimised this, anyway.

### flamegraph

<https://gist.github.com/dlaehnemann/9197dbe41bddae0856b7e280dd9992ed>

## calculate once and store prob_mismapping in observation

### libprosic commit

```
db518bc3c20c9bf60bf36f8ada1e231a53a24a6e
```

### prosolo commit

```
9bb7fc793dd58642935e461d3ed4c89f8b3b1a18
```

### times

```
real	2m43.860s
user	2m43.084s
sys	0m0.600s
```

```
real	2m43.727s
user	2m43.132s
sys	0m0.644s
```

```
real	2m43.675s
user	2m43.156s
sys	0m0.568s
```

```
real	2m46.033s
user	2m45.436s
sys	0m0.620
```

```
((2+2+2+2)*60+43,084+43,132+43,156+45,436)/4 = 163,702
```

This looks like a meaningful speedup of about 15% compared to the latest previous master branch runtime (PR #46). That these changes lead to meaningful differences to how the libprosic code is compiled is also shown in the flamegraph below, compared to the ones above (that do not really change compared to PR #46).

### flamegraph

<https://gist.github.com/dlaehnemann/de2d990fc0b458deb62c42314a071bd5>
