### PR TITLE
fdr control: properly handle very low requested alphas and add test

### DIFF
--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -61,14 +61,19 @@ where
             .collect_vec();
         let fdrs = bayesian::expected_fdr(&pep_dist);
 
-        // find the largest pep for which fdr <= alpha
-        // do not let peps with the same value cross the boundary
-        for i in (0..fdrs.len()).rev() {
-            if fdrs[i] <= alpha && (i == 0 || pep_dist[i] != pep_dist[i - 1]) {
-                let pep = pep_dist[i];
+        if fdrs[0] > alpha {
+            threshold = Some(LogProb::ln_one());
+        } else {
 
-                threshold = Some(pep.ln_one_minus_exp());
-                break;
+            // find the largest pep for which fdr <= alpha
+            // do not let peps with the same value cross the boundary
+            for i in (0..fdrs.len()).rev() {
+                if fdrs[i] <= alpha && (i == 0 || pep_dist[i] != pep_dist[i - 1]) {
+                    let pep = pep_dist[i];
+
+                    threshold = Some(pep.ln_one_minus_exp());
+                    break;
+                }
             }
         }
     }

--- a/src/estimation/fdr/ev.rs
+++ b/src/estimation/fdr/ev.rs
@@ -64,7 +64,6 @@ where
         if fdrs[0] > alpha {
             threshold = Some(LogProb::ln_one());
         } else {
-
             // find the largest pep for which fdr <= alpha
             // do not let peps with the same value cross the boundary
             for i in (0..fdrs.len()).rev() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -306,7 +306,6 @@ fn call_single_cell_bulk(test: &str, exclusive_end: bool, chrom: &str) {
     thread::sleep(time::Duration::from_secs(1));
 }
 
-
 fn load_call(test: &str) -> bcf::Record {
     let basedir = basedir(test);
 
@@ -338,7 +337,6 @@ fn assert_call_number(test: &str, expected_calls: usize) {
     let calls = reader.records().map(|r| r.unwrap()).collect_vec();
     assert_eq!(calls.len(), expected_calls, "unexpected number of calls");
 }
-
 
 fn control_fdr_ev(test: &str, event_str: &str, alpha: f64) {
     let basedir = basedir(test);
@@ -627,7 +625,6 @@ fn test_fdr_ev2_low_alpha() {
     control_fdr_ev("test_fdr_ev_2", "ABSENT", 0.001);
     assert_call_number("test_fdr_ev_2", 0);
 }
-
 
 #[test]
 fn test_sc_bulk() {


### PR DESCRIPTION
This is a corner case I came across in prosolo, where I was controlling the probabilities for whole genome amplification errors that rarely are really high, meaning that using low alphas triggered this bug: If no entry has a probability high enough to pass above the respective threshold for that alpha, no filtering is applied at all, instead of filtering out all entries. This is what happens now.