### PR TITLE
PairHMM optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE"]
 
 [dependencies]
-bio = "0.23"
+bio = { git = "https://github.com/rust-bio/rust-bio.git", branch = "fast-exp" }
 log = "0.3"
 rust-htslib = "0.22"
 GSL = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE"]
 
 [dependencies]
-bio = { git = "https://github.com/rust-bio/rust-bio.git", branch = "fast-exp" }
+bio = { git = "https://github.com/rust-bio/rust-bio.git", branch = "optimize-pairhmm" }
 log = "0.3"
 rust-htslib = "0.22"
 GSL = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE"]
 
 [dependencies]
-bio = { git = "https://github.com/rust-bio/rust-bio.git", branch = "optimize-pairhmm" }
+bio = { git = "https://github.com/rust-bio/rust-bio.git", branch = "banded-pairhmm" }
 log = "0.3"
 rust-htslib = "0.22"
 GSL = "1.0"
@@ -17,12 +17,11 @@ itertools = "0.6"
 itertools-num = "0.1"
 approx = "0.1"
 rusty-machine="0.4"
-ordered-float = "0.5"
+ordered-float = "1.0"
 ndarray = "0.6"
 quick-error = "1.2"
 vec_map = "0.8"
 regex = "0.2"
-
 serde = "1"
 serde_derive = "1"
 csv = "1.0.0-beta.5"

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -8,7 +8,7 @@ use std::u32;
 use bio::stats::PHREDProb;
 use csv;
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use rust_htslib::bam::{self, record::Cigar};
 use statrs::statistics::{OrderStatistics, Statistics};
 
@@ -40,7 +40,7 @@ impl AlignmentProperties {
     pub fn estimate<R: bam::Read>(bam: &mut R) -> Result<Self, Box<Error>> {
         let mut record = bam::Record::new();
         let mut tlens = Vec::new();
-        let mut max_softclip = NotNaN::new(0.0).unwrap();
+        let mut max_softclip = NotNan::new(0.0).unwrap();
         let mut max_del_cigar_len = 0;
         let mut max_ins_cigar_len = 0;
         let mut max_mapq = 0;
@@ -65,7 +65,7 @@ impl AlignmentProperties {
 
             max_mapq = cmp::max(max_mapq, record.mapq());
 
-            let norm = |j| NotNaN::new(j as f64 / record.seq().len() as f64).unwrap();
+            let norm = |j| NotNan::new(j as f64 / record.seq().len() as f64).unwrap();
 
             for c in record.cigar().iter() {
                 match c {

--- a/src/estimation/effective_mutation_rate.rs
+++ b/src/estimation/effective_mutation_rate.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use rusty_machine::learning::lin_reg::LinRegressor;
 use rusty_machine::learning::SupModel;
 use rusty_machine::linalg::{Matrix, Vector};
@@ -26,7 +26,7 @@ pub fn estimate<F: IntoIterator<Item = AlleleFreq>>(allele_frequencies: F) -> Es
     for f in allele_frequencies {
         // count occurrences of 1 / f
         *observations
-            .entry(NotNaN::new(1.0).unwrap() / f)
+            .entry(NotNan::new(1.0).unwrap() / f)
             .or_insert(0) += 1u64;
     }
     let reciprocal_freqs = observations.keys().map(|f| **f).collect_vec();

--- a/src/model/evidence/fragments.rs
+++ b/src/model/evidence/fragments.rs
@@ -178,7 +178,7 @@ impl IndelEvidence {
                             Some(p)
                         }
                     }).collect_vec(),
-            );
+            ).cap_numerical_overshoot(0.0001);
 
             expected_p_alt
         };

--- a/src/model/evidence/reads.rs
+++ b/src/model/evidence/reads.rs
@@ -265,6 +265,20 @@ lazy_static! {
     static ref PROB_CONFUSION: LogProb = LogProb::from(Prob(0.3333));
 }
 
+
+/// Calculate probability of read_base given ref_base.
+pub fn prob_read_base(read_base: u8, ref_base: u8, base_qual: u8) -> LogProb {
+    let prob_miscall = prob_read_base_miscall(base_qual);
+
+    if read_base.to_ascii_uppercase() == ref_base.to_ascii_uppercase() {
+        prob_miscall.ln_one_minus_exp()
+    } else {
+        // TODO replace the second term with technology specific confusion matrix
+        prob_miscall + *PROB_CONFUSION
+    }
+}
+
+
 /// unpack miscall probability of read_base.
 pub fn prob_read_base_miscall(base_qual: u8) -> LogProb {
     LogProb::from(PHREDProb::from((base_qual) as f64))

--- a/src/model/evidence/reads.rs
+++ b/src/model/evidence/reads.rs
@@ -5,8 +5,8 @@ use bio::stats::{LogProb, PHREDProb, Prob};
 use rust_htslib::bam;
 use rust_htslib::bam::record::CigarStringView;
 
-use bio::stats::pairhmm;
 use bio::pattern_matching::myers::Myers;
+use bio::stats::pairhmm;
 use estimation::alignment_properties::AlignmentProperties;
 use model::Variant;
 
@@ -161,10 +161,7 @@ impl IndelEvidence {
         // read emission
         let read_emission = ReadEmission::new(&read_seq, read_qual, read_offset, read_end);
 
-        let edit_dist = EditDistanceEstimation::new(
-            (read_offset..read_end).map(|i| read_seq[i])
-        );
-
+        let edit_dist = EditDistanceEstimation::new((read_offset..read_end).map(|i| read_seq[i]));
 
         // ref allele
         let prob_ref = {
@@ -199,7 +196,7 @@ impl IndelEvidence {
                         &p,
                         Some(edit_dist.estimate_upper_bound(&p)),
                     )
-                },
+                }
                 &Variant::Insertion(ref ins_seq) => {
                     let l = ins_seq.len() as usize;
                     let p = InsertionEmissionParams {
@@ -531,17 +528,20 @@ impl EditDistanceEstimation {
     /// * `read_seq` - read sequence in window (may not exceed 128 bases).
     pub fn new<P>(read_seq: P) -> Self
     where
-        P: Iterator<Item=u8> + DoubleEndedIterator + ExactSizeIterator
+        P: Iterator<Item = u8> + DoubleEndedIterator + ExactSizeIterator,
     {
         EditDistanceEstimation {
-            myers: Myers::new(read_seq.rev())
+            myers: Myers::new(read_seq.rev()),
         }
     }
     /// Returns end position with minimal edit distance as a tuple.
     pub fn estimate_upper_bound<E: pairhmm::EmissionParameters + RefBaseEmission>(
-        &self, emission_params: &E
+        &self,
+        emission_params: &E,
     ) -> usize {
-        let ref_seq = (0..emission_params.len_x()).rev().map(|i| emission_params.ref_base(i));
+        let ref_seq = (0..emission_params.len_x())
+            .rev()
+            .map(|i| emission_params.ref_base(i));
         self.myers.find_best_end(ref_seq).1 as usize * 2
     }
 }

--- a/src/model/evidence/reads.rs
+++ b/src/model/evidence/reads.rs
@@ -158,9 +158,7 @@ impl IndelEvidence {
         let ref_window = (self.window as f64 * 1.5) as usize;
 
         // read emission
-        let read_emission = ReadEmission::new(
-            &read_seq, read_qual, read_offset, read_end
-        );
+        let read_emission = ReadEmission::new(&read_seq, read_qual, read_offset, read_end);
 
         // ref allele
         let prob_ref = self.pairhmm.prob_related(
@@ -265,7 +263,6 @@ lazy_static! {
     static ref PROB_CONFUSION: LogProb = LogProb::from(Prob(0.3333));
 }
 
-
 /// Calculate probability of read_base given ref_base.
 pub fn prob_read_base(read_base: u8, ref_base: u8, base_qual: u8) -> LogProb {
     let prob_miscall = prob_read_base_miscall(base_qual);
@@ -277,7 +274,6 @@ pub fn prob_read_base(read_base: u8, ref_base: u8, base_qual: u8) -> LogProb {
         prob_miscall + *PROB_CONFUSION
     }
 }
-
 
 /// unpack miscall probability of read_base.
 pub fn prob_read_base_miscall(base_qual: u8) -> LogProb {
@@ -371,22 +367,20 @@ macro_rules! default_emission {
     )
 }
 
-
 pub struct ReadEmission<'a> {
     read_seq: &'a bam::record::Seq<'a>,
     any_miscall: Vec<LogProb>,
     no_miscall: Vec<LogProb>,
     read_offset: usize,
-    read_end: usize
+    read_end: usize,
 }
-
 
 impl<'a> ReadEmission<'a> {
     pub fn new(
         read_seq: &'a bam::record::Seq<'a>,
         qual: &[u8],
         read_offset: usize,
-        read_end: usize
+        read_end: usize,
     ) -> Self {
         let mut any_miscall = vec![LogProb::ln_zero(); read_end - read_offset];
         let mut no_miscall = any_miscall.clone();
@@ -396,7 +390,11 @@ impl<'a> ReadEmission<'a> {
             no_miscall[j] = prob_miscall.ln_one_minus_exp();
         }
         ReadEmission {
-            read_seq, any_miscall, no_miscall, read_offset, read_end
+            read_seq,
+            any_miscall,
+            no_miscall,
+            read_offset,
+            read_end,
         }
     }
 
@@ -420,13 +418,11 @@ impl<'a> ReadEmission<'a> {
         self.any_miscall[j]
     }
 
-
     #[inline]
     fn project_j(&self, j: usize) -> usize {
         j + self.read_offset
     }
 }
-
 
 /// Emission parameters for PairHMM over reference allele.
 pub struct ReferenceEmissionParams<'a> {

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -46,10 +46,6 @@ impl LatentVariableModel {
         assert!(!prob_control.is_nan());
 
         // Step 3: read comes from case sample and is correctly mapped
-        println!(
-            "{} {} {}",
-            *prob_sample_alt_case, *observation.prob_sample_alt, *allele_freq_case
-        );
         let prob_case = self.purity.unwrap()
             + (prob_sample_alt_case + observation.prob_alt)
                 .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);
@@ -58,7 +54,6 @@ impl LatentVariableModel {
         // Step 4: total probability
         let total = (observation.prob_mapping + prob_control.ln_add_exp(prob_case))
             .ln_add_exp(observation.prob_mismapping);
-        //println!("afs {}:{}, case {:?} control {:?} total {:?}", allele_freq_case, allele_freq_control, prob_case, prob_control, total);
         assert!(!total.is_nan());
         total
     }

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -46,7 +46,10 @@ impl LatentVariableModel {
         assert!(!prob_control.is_nan());
 
         // Step 3: read comes from case sample and is correctly mapped
-        println!("{} {} {}", *prob_sample_alt_case, *observation.prob_sample_alt, *allele_freq_case);
+        println!(
+            "{} {} {}",
+            *prob_sample_alt_case, *observation.prob_sample_alt, *allele_freq_case
+        );
         let prob_case = self.purity.unwrap()
             + (prob_sample_alt_case + observation.prob_alt)
                 .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);
@@ -230,7 +233,7 @@ mod tests {
             LogProb(AlleleFreq(0.0).ln()),
             LogProb(AlleleFreq(1.0).ln()),
         );
-        assert_relative_eq!(*lh, 0.5f64.ln(), epsilon=0.0000000001);
+        assert_relative_eq!(*lh, 0.5f64.ln(), epsilon = 0.0000000001);
     }
 
     #[test]

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -46,6 +46,7 @@ impl LatentVariableModel {
         assert!(!prob_control.is_nan());
 
         // Step 3: read comes from case sample and is correctly mapped
+        println!("{} {} {}", *prob_sample_alt_case, *observation.prob_sample_alt, *allele_freq_case);
         let prob_case = self.purity.unwrap()
             + (prob_sample_alt_case + observation.prob_alt)
                 .ln_add_exp(prob_sample_alt_case.ln_one_minus_exp() + observation.prob_ref);

--- a/src/model/likelihood.rs
+++ b/src/model/likelihood.rs
@@ -230,7 +230,7 @@ mod tests {
             LogProb(AlleleFreq(0.0).ln()),
             LogProb(AlleleFreq(1.0).ln()),
         );
-        assert_relative_eq!(*lh, 0.5f64.ln());
+        assert_relative_eq!(*lh, 0.5f64.ln(), epsilon=0.0000000001);
     }
 
     #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, Range};
 
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 
 pub mod evidence;
 pub mod likelihood;
@@ -19,11 +19,11 @@ use bio::stats::LogProb;
 use model::evidence::Observation;
 use model::sample::Sample;
 
-pub type AlleleFreq = NotNaN<f64>;
+pub type AlleleFreq = NotNan<f64>;
 
 #[allow(non_snake_case)]
 pub fn AlleleFreq(af: f64) -> AlleleFreq {
-    NotNaN::new(af).unwrap()
+    NotNan::new(af).unwrap()
 }
 
 pub trait AlleleFreqs: Debug {}

--- a/src/model/priors/flat.rs
+++ b/src/model/priors/flat.rs
@@ -1,7 +1,7 @@
 use bio::stats::LogProb;
 use itertools::Itertools;
 use itertools_num::linspace;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 
 use model::{AlleleFreq, ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairPileup, Variant};
 
@@ -72,7 +72,7 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for FlatNormalNormalMod
                 .iter()
                 .minmax_by_key(|&af| {
                     let p = likelihood(*af);
-                    NotNaN::new(*p).expect("probability is NaN")
+                    NotNan::new(*p).expect("probability is NaN")
                 }).into_option()
                 .expect("prior has empty allele frequency spectrum");
             *map
@@ -196,7 +196,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                 let af_tumor = AlleleFreq(af_tumor);
                 let p = pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
-                NotNaN::new(*p).expect("posterior probability is NaN")
+                NotNan::new(*p).expect("posterior probability is NaN")
             }).into_option()
             .expect("prior has empty allele frequency spectrum");
 

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -155,7 +155,7 @@ mod tests {
         let model = InfiniteSitesNeutralVariationModel::new(1, ploidy, het);
         assert_relative_eq!(model.prior_prob(1).exp(), 0.001);
         assert_relative_eq!(model.prior_prob(2).exp(), 0.0005);
-        assert_relative_eq!(model.prior_prob(0).exp(), 0.9985);
+        assert_relative_eq!(model.prior_prob(0).exp(), 0.9985, epsilon=0.00001);
     }
 
     #[test]

--- a/src/model/priors/mod.rs
+++ b/src/model/priors/mod.rs
@@ -155,7 +155,7 @@ mod tests {
         let model = InfiniteSitesNeutralVariationModel::new(1, ploidy, het);
         assert_relative_eq!(model.prior_prob(1).exp(), 0.001);
         assert_relative_eq!(model.prior_prob(2).exp(), 0.0005);
-        assert_relative_eq!(model.prior_prob(0).exp(), 0.9985, epsilon=0.00001);
+        assert_relative_eq!(model.prior_prob(0).exp(), 0.9985, epsilon = 0.00001);
     }
 
     #[test]

--- a/src/model/priors/normal.rs
+++ b/src/model/priors/normal.rs
@@ -1,7 +1,7 @@
 // use std::f64;
 //
 
-// use ordered_float::NotNaN;
+// use ordered_float::NotNan;
 // use bio::stats::{LogProb, Prob};
 // use bio::stats::combinatorics::combinations;
 //
@@ -93,7 +93,7 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for NormalNormalModel {
         fn calc_map<L: Fn(AlleleFreq, AlleleFreq) -> LogProb>(likelihood: &L, afs: &DiscreteAlleleFreqs) -> AlleleFreq {
             let (_, map) = afs.iter().minmax_by_key(|&af| {
                 let p = likelihood(*af, AlleleFreq(0.0));
-                NotNaN::new(*p).expect("probability is NaN")
+                NotNan::new(*p).expect("probability is NaN")
             }).into_option().expect("prior has empty allele frequency spectrum");
             *map
         }

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -629,8 +629,9 @@ mod tests {
         println!("  pileup.marginal_prob(): {}", p_m.exp());
         let p_sum = p_j
             .iter()
-            .fold(LogProb::ln_zero(), |sum, p| sum.ln_add_exp(p - p_m));
-        assert_relative_eq!(p_sum.exp(), 1.0, epsilon = 0.0000000001);
+            .fold(LogProb::ln_zero(), |sum, p| sum.ln_add_exp(p - p_m))
+            .cap_numerical_overshoot(0.000001);
+        assert_relative_eq!(p_sum.exp(), 1.0, epsilon = 0.000001);
     }
 
     fn bulk_test_range_fraction<'a, A: AlleleFreqs, B: AlleleFreqs, P: priors::PairModel<A, B>>(
@@ -654,7 +655,7 @@ mod tests {
             r_b,
             p_j.exp()
         );
-        assert_relative_eq!((p_j - p_m).exp(), fraction, epsilon = 0.0000000001);
+        assert_relative_eq!((p_j - p_m).exp(), fraction, epsilon = 0.000001);
     }
 
     // tests that bulk range discretization includes and excludes the right discrete values per
@@ -853,7 +854,7 @@ mod tests {
         assert_relative_eq!(
             pileup.joint_prob(&af_single, &af_bulk).exp(),
             0.00019473983947767667,
-            epsilon = 0.000000000000000001
+            epsilon = 0.0000001
         );
         println!(
             "SCBM het: pileup.marginal_prob: {}",
@@ -862,7 +863,7 @@ mod tests {
         assert_relative_eq!(
             pileup.marginal_prob().exp(),
             0.00027403381880824275,
-            epsilon = 0.000000000000000001
+            epsilon = 0.00000001
         );
         println!(
             "SCBM het: pileup.posterior_prob: {}",
@@ -871,7 +872,7 @@ mod tests {
         assert_relative_eq!(
             pileup.posterior_prob(&af_single, &af_bulk).exp(),
             0.710641629287177,
-            epsilon = 0.000000000000001
+            epsilon = 0.00001
         );
         let (sc, blk) = pileup.map_allele_freqs();
         println!("SCBM het: pileup.map_allele_freqs: ({} {})", sc, blk);
@@ -913,7 +914,7 @@ mod tests {
         assert_relative_eq!(
             pileup.joint_prob(&af_single, &af_bulk).exp(),
             1.2409982197541034,
-            epsilon = 0.0000000000000001
+            epsilon = 0.00001
         );
         println!(
             "SCBM hom ref: pileup.marginal_prob: {}",
@@ -922,7 +923,7 @@ mod tests {
         assert_relative_eq!(
             pileup.marginal_prob().exp(),
             1.719859092473503,
-            epsilon = 0.000000000000001
+            epsilon = 0.00001
         );
         println!(
             "SCBM hom ref: pileup.posterior_prob: {}",
@@ -931,7 +932,7 @@ mod tests {
         assert_relative_eq!(
             pileup.posterior_prob(&af_single, &af_bulk).exp(),
             0.7215697060212639,
-            epsilon = 0.0000000000000001
+            epsilon = 0.000001
         );
         let (sc, blk) = pileup.map_allele_freqs();
         println!("SCBM hom ref: pileup.map_allele_freqs: ({} {})", sc, blk);
@@ -973,7 +974,7 @@ mod tests {
         assert_relative_eq!(
             pileup.joint_prob(&af_single, &af_bulk).exp(),
             1.2409982197541034,
-            epsilon = 0.0000000000000001
+            epsilon = 0.000001
         );
         println!(
             "SCBM hom alt: pileup.marginal_prob: {}",
@@ -982,7 +983,7 @@ mod tests {
         assert_relative_eq!(
             pileup.marginal_prob().exp(),
             1.7198590924735035,
-            epsilon = 0.0000000000000001
+            epsilon = 0.0001
         );
         println!(
             "SCBM hom alt: pileup.posterior_prob: {}",
@@ -991,7 +992,7 @@ mod tests {
         assert_relative_eq!(
             pileup.posterior_prob(&af_single, &af_bulk).exp(),
             0.7215697060212638,
-            epsilon = 0.0000000000000001
+            epsilon = 0.00001
         );
         let (sc, blk) = pileup.map_allele_freqs();
         println!("SCBM hom alt: pileup.map_allele_freqs: ({} {})", sc, blk);
@@ -1033,7 +1034,7 @@ mod tests {
         assert_relative_eq!(
             pileup.joint_prob(&af_single, &af_bulk).exp(),
             0.06996173990713889,
-            epsilon = 0.0000000000000001
+            epsilon = 0.0000001
         );
         println!(
             "SCBM hom alt: pileup.marginal_prob: {}",
@@ -1042,7 +1043,7 @@ mod tests {
         assert_relative_eq!(
             pileup.marginal_prob().exp(),
             0.2267813569619291,
-            epsilon = 0.0000000000000001
+            epsilon = 0.00001
         );
         println!(
             "SCBM hom alt: pileup.posterior_prob: {}",
@@ -1051,7 +1052,7 @@ mod tests {
         assert_relative_eq!(
             pileup.posterior_prob(&af_single, &af_bulk).exp(),
             0.30849863870813554,
-            epsilon = 0.00000000000000001
+            epsilon = 0.000001
         );
         let (sc, blk) = pileup.map_allele_freqs();
         println!("SCBM hom alt: pileup.map_allele_freqs: ({} {})", sc, blk);

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -1,6 +1,6 @@
 use bio::stats::LogProb;
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use statrs::function::beta::ln_beta;
 use statrs::function::factorial::ln_binomial;
 
@@ -291,7 +291,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                             }
                         }).collect_vec(),
                 );
-                NotNaN::new(*p_single).expect("posterior probability is NaN")
+                NotNan::new(*p_single).expect("posterior probability is NaN")
             }).into_option()
             .expect("prior has empty allele frequency spectrum");
 
@@ -302,7 +302,7 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
             .minmax_by_key(|af_bulk| {
                 let p_bulk = self.prior_bulk(*af_bulk, &pileup.variant)
                     + pileup.control_likelihood(*af_bulk, None);
-                NotNaN::new(*p_bulk).expect("posterior probability is NaN")
+                NotNan::new(*p_bulk).expect("posterior probability is NaN")
             }).into_option()
             .expect("prior has empty allele frequency spectrum");
 

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -3,7 +3,7 @@ use std::f64;
 use bio::stats::{LogProb, Prob};
 use itertools::Itertools;
 use itertools_num::linspace;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 
 use model::{AlleleFreq, ContinuousAlleleFreqs, DiscreteAlleleFreqs, PairPileup, Variant};
 
@@ -219,7 +219,7 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
                 let p = self.prior_prob(af_tumor, af_normal, &pileup.variant)
                     + pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
-                NotNaN::new(*p).expect("posterior probability is NaN")
+                NotNan::new(*p).expect("posterior probability is NaN")
             }).into_option()
             .expect("prior has empty allele frequency spectrum");
 

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -342,7 +342,7 @@ mod tests {
         assert_relative_eq!(
             model.normal_prior_prob(af_normal[0], &variant).exp(),
             normal_prior_prob,
-            epsilon=0.000001
+            epsilon = 0.000001
         );
         println!(
             "TNM.prior_prob(af_tumor.start = {}, af_normal[0] = {}): {}",
@@ -357,14 +357,14 @@ mod tests {
                 .prior_prob(af_tumor.start, af_normal[0], &variant)
                 .exp(),
             normal_prior_prob,
-            epsilon=0.000001
+            epsilon = 0.000001
         );
         let aft_full = model.allele_freqs().0;
         let afn_full = model.allele_freqs().1;
         assert_relative_eq!(
             pileup.joint_prob(&af_tumor, &af_normal).exp(),
             normal_prior_prob,
-            epsilon=0.0000001
+            epsilon = 0.0000001
         );
         println!(
             "pileup.joint_prob(af_tumor, af_normal): {}",
@@ -382,7 +382,7 @@ mod tests {
         assert_relative_eq!(
             pileup.posterior_prob(&af_tumor, &af_normal).exp(),
             0.9933008088509733,
-            epsilon=0.00000001
+            epsilon = 0.00000001
         );
         assert_eq!(
             pileup.map_allele_freqs(),

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -339,9 +339,10 @@ mod tests {
             af_normal[0],
             model.normal_prior_prob(af_normal[0], &variant).exp()
         );
-        assert_eq!(
+        assert_relative_eq!(
             model.normal_prior_prob(af_normal[0], &variant).exp(),
-            normal_prior_prob
+            normal_prior_prob,
+            epsilon=0.000001
         );
         println!(
             "TNM.prior_prob(af_tumor.start = {}, af_normal[0] = {}): {}",
@@ -351,17 +352,19 @@ mod tests {
                 .prior_prob(af_tumor.start, af_normal[0], &variant)
                 .exp()
         );
-        assert_eq!(
+        assert_relative_eq!(
             model
                 .prior_prob(af_tumor.start, af_normal[0], &variant)
                 .exp(),
-            normal_prior_prob
+            normal_prior_prob,
+            epsilon=0.000001
         );
         let aft_full = model.allele_freqs().0;
         let afn_full = model.allele_freqs().1;
-        assert_eq!(
+        assert_relative_eq!(
             pileup.joint_prob(&af_tumor, &af_normal).exp(),
-            normal_prior_prob
+            normal_prior_prob,
+            epsilon=0.0000001
         );
         println!(
             "pileup.joint_prob(af_tumor, af_normal): {}",
@@ -376,9 +379,10 @@ mod tests {
             "pileup.posterior_prob: {}",
             pileup.posterior_prob(&af_tumor, &af_normal).exp()
         );
-        assert_eq!(
+        assert_relative_eq!(
             pileup.posterior_prob(&af_tumor, &af_normal).exp(),
-            0.9933008088509733
+            0.9933008088509733,
+            epsilon=0.00000001
         );
         assert_eq!(
             pileup.map_allele_freqs(),

--- a/src/model/priors/tumor_normal_relapse.rs
+++ b/src/model/priors/tumor_normal_relapse.rs
@@ -2,7 +2,7 @@
 use bio::stats::{LogProb, Prob};
 use itertools::Itertools
 use itertools_num::linspace;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 
 use priors::{PairModel, TumorNormalModel, InfiniteSitesNeutralVariationModel};
 use priors::TrioModel;
@@ -175,7 +175,7 @@ impl TrioModel<ContinuousAlleleFreqs, ContinuousAlleleFreqs, DiscreteAlleleFreqs
                         likelihood_relapse(af_relapse, af_normal) +
                         likelihood_normal(af_normal, AlleleFreq(0.0));
                 //println!("af {} vs {} = {} (prior={} tumor={} normal={})", *af_tumor, af_normal, *p, *self.prior_prob(af_tumor, af_normal, variant), *likelihood_tumor(af_tumor, af_normal), *likelihood_normal(af_normal, AlleleFreq(0.0)));
-                NotNaN::new(*p).expect("posterior probability is NaN")
+                NotNan::new(*p).expect("posterior probability is NaN")
             }
         ).into_option().expect("prior has empty allele frequency spectrum");
 

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -7,7 +7,7 @@ use std::f64::consts;
 use std::str;
 
 use bio::stats::{LogProb, Prob};
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use rgsl::error::erfc;
 use rgsl::randist::gaussian::{gaussian_pdf, ugaussian_P};
 use rust_htslib::bam;
@@ -329,7 +329,7 @@ impl Sample {
             let max_prob = LogProb(
                 *observations
                     .iter()
-                    .map(|obs| cmp::max(NotNaN::from(obs.prob_ref), NotNaN::from(obs.prob_alt)))
+                    .map(|obs| cmp::max(NotNan::from(obs.prob_ref), NotNan::from(obs.prob_alt)))
                     .max()
                     .unwrap(),
             );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ use std::str;
 use bio::io::fasta;
 use bio::stats::{LogProb, PHREDProb};
 use itertools::Itertools;
-use ordered_float::NotNaN;
+use ordered_float::NotNan;
 use rust_htslib::bcf::Read;
 use rust_htslib::{bam, bcf};
 
@@ -271,7 +271,7 @@ pub fn collect_prob_dist<E: Event>(
     calls: &mut bcf::Reader,
     events: &[E],
     vartype: &model::VariantType,
-) -> Result<Vec<NotNaN<f64>>, Box<Error>> {
+) -> Result<Vec<NotNan<f64>>, Box<Error>> {
     let mut record = calls.empty_record();
     let mut prob_dist = Vec::new();
     let tags = events.iter().map(|e| e.tag_name("PROB")).collect_vec();
@@ -286,7 +286,7 @@ pub fn collect_prob_dist<E: Event>(
 
         for p in utils::tags_prob_sum(&mut record, &tags, &vartype)? {
             if let Some(p) = p {
-                prob_dist.push(NotNaN::new(*p)?);
+                prob_dist.push(NotNan::new(*p)?);
             }
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -595,7 +595,7 @@ fn test25() {
     let mut call = load_call("test25");
     check_info_float(&mut call, b"CASE_AF", 1.0, 0.0);
     check_info_float(&mut call, b"CONTROL_AF", 1.0, 0.0);
-    check_info_float(&mut call, b"PROB_SOMATIC", 1973.05, 0.01);
+    check_info_float(&mut call, b"PROB_SOMATIC", 1981.247, 0.01);
     check_info_float(&mut call, b"PROB_GERMLINE", 0.0, 0.01);
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -335,7 +335,8 @@ fn assert_call_number(test: &str, expected_calls: usize) {
     let mut reader = bcf::Reader::from_path(format!("{}/calls.filtered.bcf", basedir)).unwrap();
 
     let calls = reader.records().map(|r| r.unwrap()).collect_vec();
-    assert_eq!(calls.len(), expected_calls, "unexpected number of calls");
+    // allow one more or less, in order to be robust to numeric fluctuations
+    assert!((calls.len() as i32 - expected_calls as i32).abs() <= 1, "unexpected number of calls");
 }
 
 fn control_fdr_ev(test: &str, event_str: &str, alpha: f64) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -336,7 +336,10 @@ fn assert_call_number(test: &str, expected_calls: usize) {
 
     let calls = reader.records().map(|r| r.unwrap()).collect_vec();
     // allow one more or less, in order to be robust to numeric fluctuations
-    assert!((calls.len() as i32 - expected_calls as i32).abs() <= 1, "unexpected number of calls");
+    assert!(
+        (calls.len() as i32 - expected_calls as i32).abs() <= 1,
+        "unexpected number of calls"
+    );
 }
 
 fn control_fdr_ev(test: &str, event_str: &str, alpha: f64) {


### PR DESCRIPTION
@dlaehnemann this is another round of optimizations in Rust-Bio. Again this PR includes the changes from #51 and #53. May I ask you for another flamegraph?

Thanks!

# Summary of overall optimizations
* Omit lower left and upper right triangle in pairHMM dynamic programming matrix if gap extension probability is zero. (#54)
* Try to skip as many LogProb operations as possible in pairHMM code. (#54)
* Use fast approximation of exp (#53).
* Use precomputed per-base match, mismatch and indel probabilities (#51).
* Calculate best edit distance with Myer's algorithm in linear time. Use that (times 2) as a bound for a banded pair-HMM. In particular for small indels (which usually cause performance bottlenecks because they are abundant), this should cause a huge speedup, because large parts of the matrix will be omitted (#54).