### PR TITLE
cap_numerical_overshoot: increase acceptable overshoot to 0.0001

### DIFF
--- a/src/call/pairwise.rs
+++ b/src/call/pairwise.rs
@@ -24,7 +24,8 @@ fn phred_scale<'a, I: IntoIterator<Item = &'a Option<LogProb>>>(probs: I) -> Vec
         .map(|&p| match p {
             Some(p) => PHREDProb::from(p).abs() as f32,
             None => f32::missing(),
-        }).collect_vec()
+        })
+        .collect_vec()
 }
 
 pub struct PairEvent<A: AlleleFreqs, B: AlleleFreqs> {
@@ -155,12 +156,10 @@ where
     };
 
     let mut outobs = if let Some(f) = outobs {
-        let mut writer = try!(
-            csv::WriterBuilder::new()
-                .has_headers(false)
-                .delimiter(b'\t')
-                .from_path(f)
-        );
+        let mut writer = try!(csv::WriterBuilder::new()
+            .has_headers(false)
+            .delimiter(b'\t')
+            .from_path(f));
         // write header for observations
         writer.write_record(
             [
@@ -175,7 +174,7 @@ where
                 "prob_sample_alt",
                 "evidence",
             ]
-                .iter(),
+            .iter(),
         )?;
         Some(writer)
     } else {

--- a/src/estimation/alignment_properties.rs
+++ b/src/estimation/alignment_properties.rs
@@ -189,7 +189,8 @@ mod tests {
     fn test_parse_insert_size() {
         let insert_size = InsertSize::from_samtools_stats(&mut io::BufReader::new(
             fs::File::open("tests/resources/samtools_stats.example.txt").unwrap(),
-        )).unwrap();
+        ))
+        .unwrap();
         assert_relative_eq!(insert_size.mean, 311.7);
         assert_relative_eq!(insert_size.sd, 15.5);
     }

--- a/src/estimation/effective_mutation_rate.rs
+++ b/src/estimation/effective_mutation_rate.rs
@@ -36,7 +36,8 @@ pub fn estimate<F: IntoIterator<Item = AlleleFreq>>(allele_frequencies: F) -> Es
         .scan(0.0, |s, c| {
             *s += *c as f64;
             Some(*s)
-        }).collect_vec();
+        })
+        .collect_vec();
 
     let observations = reciprocal_freqs
         .iter()

--- a/src/model/evidence/fragments.rs
+++ b/src/model/evidence/fragments.rs
@@ -177,8 +177,10 @@ impl IndelEvidence {
                             assert!(p.is_valid(), "bug: invalid probability {:?}", p);
                             Some(p)
                         }
-                    }).collect_vec(),
-            ).cap_numerical_overshoot(0.0001);
+                    })
+                    .collect_vec(),
+            )
+            .cap_numerical_overshoot(0.0001);
 
             expected_p_alt
         };

--- a/src/model/evidence/mod.rs
+++ b/src/model/evidence/mod.rs
@@ -76,7 +76,8 @@ pub fn max_indel(cigar: &CigarStringView) -> u32 {
             &Cigar::Ins(l) => l,
             &Cigar::Del(l) => l,
             _ => 0,
-        }).max()
+        })
+        .max()
         .unwrap_or(0)
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -586,7 +586,7 @@ mod tests {
     use rust_htslib::bam;
 
     fn setup_pairwise_test<'a>(
-) -> PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::TumorNormalModel> {
+    ) -> PairCaller<ContinuousAlleleFreqs, DiscreteAlleleFreqs, priors::TumorNormalModel> {
         let insert_size = InsertSize {
             mean: 250.0,
             sd: 50.0,

--- a/src/model/priors/flat.rs
+++ b/src/model/priors/flat.rs
@@ -45,7 +45,8 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for FlatNormalNormalMod
                     let prob = p_first + p_second;
 
                     prob
-                }).collect_vec(),
+                })
+                .collect_vec(),
         );
 
         prob
@@ -73,7 +74,8 @@ impl PairModel<DiscreteAlleleFreqs, DiscreteAlleleFreqs> for FlatNormalNormalMod
                 .minmax_by_key(|&af| {
                     let p = likelihood(*af);
                     NotNan::new(*p).expect("probability is NaN")
-                }).into_option()
+                })
+                .into_option()
                 .expect("prior has empty allele frequency spectrum");
             *map
         }
@@ -154,7 +156,8 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                     let prob = p_tumor + p_normal;
 
                     prob
-                }).collect_vec(),
+                })
+                .collect_vec(),
         );
 
         prob
@@ -197,7 +200,8 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for FlatTumorNormalMo
                 let p = pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
                 NotNan::new(*p).expect("posterior probability is NaN")
-            }).into_option()
+            })
+            .into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (AlleleFreq(map_tumor), *map_normal)

--- a/src/model/priors/single_cell_bulk.rs
+++ b/src/model/priors/single_cell_bulk.rs
@@ -198,33 +198,34 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                             + pileup.control_likelihood(af_bulk, None)
                     }
                     p
-                }).collect_vec(),
+                })
+                .collect_vec(),
         );
 
         /*
-        // do Simpson's integration instead of point-wise evaluation above
-        let density = |af_bulk| {
-            let af_bulk = AlleleFreq(af_bulk);
-            self.prior_bulk(af_bulk, variant) +
-            likelihood_bulk(af_bulk, None)
-        };
-        let grid_points = k_end - k_start;
-        println!("bulk grid_points: {}", grid_points);
+                // do Simpson's integration instead of point-wise evaluation above
+                let density = |af_bulk| {
+                    let af_bulk = AlleleFreq(af_bulk);
+                    self.prior_bulk(af_bulk, variant) +
+                    likelihood_bulk(af_bulk, None)
+                };
+                let grid_points = k_end - k_start;
+                println!("bulk grid_points: {}", grid_points);
 
-        let p_bulk = if af_bulk.start == af_bulk.end {
-                density(*af_bulk.start)
-            } else {
-                LogProb::ln_simpsons_integrate_exp(
-                    &density,
-                    *af_bulk.start,
-                    *af_bulk.end,
-                    if grid_points % 2 == 1 {
-                        grid_points
+                let p_bulk = if af_bulk.start == af_bulk.end {
+                        density(*af_bulk.start)
                     } else {
-                        grid_points + 1
-                    })
-            };
-*/
+                        LogProb::ln_simpsons_integrate_exp(
+                            &density,
+                            *af_bulk.start,
+                            *af_bulk.end,
+                            if grid_points % 2 == 1 {
+                                grid_points
+                            } else {
+                                grid_points + 1
+                            })
+                    };
+        */
 
         // go through all possible underlying single cell allele frequencies
         let prob = LogProb::ln_sum_exp(
@@ -245,12 +246,14 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                                         + pileup.case_likelihood(af_single_distorted, None)
                                         + prob_rho(af_single, n_single, k_s)
                                 }
-                            }).collect_vec(),
+                            })
+                            .collect_vec(),
                     );
                     let prob = p_bulk + p_single;
 
                     prob
-                }).collect_vec(),
+                })
+                .collect_vec(),
         );
 
         prob
@@ -289,10 +292,12 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                                     + pileup.case_likelihood(af_single_distorted, None)
                                     + prob_rho(af_single, n_single, k_s)
                             }
-                        }).collect_vec(),
+                        })
+                        .collect_vec(),
                 );
                 NotNan::new(*p_single).expect("posterior probability is NaN")
-            }).into_option()
+            })
+            .into_option()
             .expect("prior has empty allele frequency spectrum");
 
         let n_bulk = self.adjust_n_b(pileup.control.len());
@@ -303,7 +308,8 @@ impl PairModel<DiscreteAlleleFreqs, ContinuousAlleleFreqs> for SingleCellBulkMod
                 let p_bulk = self.prior_bulk(*af_bulk, &pileup.variant)
                     + pileup.control_likelihood(*af_bulk, None);
                 NotNan::new(*p_bulk).expect("posterior probability is NaN")
-            }).into_option()
+            })
+            .into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (*map_single, map_bulk)

--- a/src/model/priors/tumor_normal.rs
+++ b/src/model/priors/tumor_normal.rs
@@ -178,7 +178,8 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
                     let prob = p_tumor + p_normal;
 
                     prob
-                }).collect_vec(),
+                })
+                .collect_vec(),
         );
 
         prob
@@ -220,7 +221,8 @@ impl PairModel<ContinuousAlleleFreqs, DiscreteAlleleFreqs> for TumorNormalModel 
                     + pileup.case_likelihood(af_tumor, Some(af_normal))
                     + pileup.control_likelihood(af_normal, None);
                 NotNan::new(*p).expect("posterior probability is NaN")
-            }).into_option()
+            })
+            .into_option()
             .expect("prior has empty allele frequency spectrum");
 
         (AlleleFreq(map_tumor), *map_normal)

--- a/src/model/sample.rs
+++ b/src/model/sample.rs
@@ -531,7 +531,8 @@ pub fn isize_mixture_density_louis(value: f64, d: f64, mean: f64, sd: f64, rate:
                 - erfc((-value + 0.5 + mean) / sd * consts::FRAC_1_SQRT_2))
             + (1.0 - rate)
                 * (erfc((-value - 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2)
-                    - erfc((-value + 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2)))).ln(),
+                    - erfc((-value + 0.5 + mean + d) / sd * consts::FRAC_1_SQRT_2))))
+        .ln(),
     )
 }
 
@@ -563,12 +564,9 @@ mod tests {
         let rate = LogProb(0.05f64.ln());
         let p_alt = (
             // case: correctly called indel
-            rate.ln_one_minus_exp() + isize_pmf(
-                212.0,
-                312.0 - 100.0,
-                15.0
-            )
-        ).ln_add_exp(
+            rate.ln_one_minus_exp() + isize_pmf(212.0, 312.0 - 100.0, 15.0)
+        )
+        .ln_add_exp(
             // case: no indel, false positive call
             rate + isize_pmf(212.0, 312.0, 15.0),
         );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ use utils;
 use BCFError;
 use Event;
 
-pub const NUMERICAL_EPSILON: f64 = 1e-6;
+pub const NUMERICAL_EPSILON: f64 = 1e-4;
 
 /// Collect variants from a given ´bcf::Record`.
 pub fn collect_variants(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,7 +177,8 @@ pub fn collect_variants(
                         None
                     }
                 }
-            }).collect_vec()
+            })
+            .collect_vec()
     };
 
     Ok(variants)
@@ -256,7 +257,8 @@ fn tags_prob_sum(
             } else {
                 None
             }
-        }).collect_vec())
+        })
+        .collect_vec())
 }
 
 /// Collect distribution of posterior probabilities from a VCF file that has been written by

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -54,7 +54,8 @@ fn download_reference(chrom: &str) -> String {
             .get(&format!(
                 "http://hgdownload.cse.ucsc.edu/goldenpath/hg18/chromosomes/{}.fa.gz",
                 chrom
-            )).send()
+            ))
+            .send()
             .unwrap();
         let mut reference_stream = flate2::read::GzDecoder::new(res).unwrap();
         let mut reference_file = fs::File::create(&reference).unwrap();
@@ -174,7 +175,8 @@ fn call_tumor_normal(test: &str, exclusive_end: bool, chrom: &str) {
         Some(10000),
         Some(&observations),
         exclusive_end,
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 fn call_single_cell_bulk(test: &str, exclusive_end: bool, chrom: &str) {
@@ -300,7 +302,8 @@ fn call_single_cell_bulk(test: &str, exclusive_end: bool, chrom: &str) {
         Some(10000),
         Some(&observations),
         exclusive_end,
-    ).unwrap();
+    )
+    .unwrap();
 
     // sleep a second in order to wait for filesystem flushing
     thread::sleep(time::Duration::from_secs(1));
@@ -354,7 +357,8 @@ fn control_fdr_ev(test: &str, event_str: &str, alpha: f64) {
         }],
         &libprosic::model::VariantType::Deletion(Some(1..30)),
         LogProb::from(Prob(alpha)),
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 /// Test a Pindel call in a repeat region. It is either germline or absent, and could be called either


### PR DESCRIPTION
After a quick discussion, @johanneskoester and I decided that we feel comfortable with capping a numerical overshoot in log-space of up to 1e-04. So that's the new hard-coded value -- exposing this as a command-line parameter to the filtering functionality in prosic and prosolo would require significant extra work.